### PR TITLE
Fix conditional compile

### DIFF
--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -1,8 +1,8 @@
 use crate::gpio::{GPIOConfig, GPIOState};
 
-#[cfg_attr(feature="pico", path="pico.rs")]
-#[cfg_attr(feature="pi", path="pi.rs")]
-#[cfg_attr(not(any(feature="pico", feature="pi")), path="none.rs")]
+#[cfg_attr(all(feature = "pico", not(feature = "pi")), path = "pico.rs")]
+#[cfg_attr(all(feature = "pi", not(feature = "pico")), path = "pi.rs")]
+#[cfg_attr(not(any(feature = "pico", feature = "pi")), path = "none.rs")]
 mod implementation;
 
 pub fn get() -> impl Hardware {


### PR DESCRIPTION
pi and pico features need to be mutually exclusive, and if neither is used then it's "none" hardware