### PR TITLE
Fix rendering on pi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ gui = ["iced", "tokio", "serde"]
 rppal = { version = "0.18.0", optional = true }
 
 # for GUI
-iced = { version = "0.12.1", features = ["tokio", "debug", "canvas", "advanced"], optional = true }
-iced_aw = { version = "0.9.3", default-features = false, features = ["tabs", "card", "modal", ], optional = true }
+iced = { version = "0.12.1", default-features= false, features = ["tokio", "debug", "canvas", "advanced"], optional = true }
+iced_aw = { version = "0.9.3", default-features = false, features = ["tabs", "card", "modal",] , optional = true }
 iced_native = { version = "0.10.3", optional = true }
 tokio = { version = "1", features = ["sync"], optional = true }
 serde = { version = "1.0.202", features = ["derive"], optional = true }


### PR DESCRIPTION
Disable default features in iced, which disables "wgpu" feature, causing rendering to be done by tiny-skia, which fixes all the horrible rendering issues on Raspberry Pi.