### PR TITLE
HW Listener to handle hardware exclusively

### DIFF
--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -17,7 +17,7 @@ pub fn get() -> impl Hardware {
     implementation::get()
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HardwareDescriptor {
     pub hardware: String,
     pub revision: String,

--- a/src/hw_listener.rs
+++ b/src/hw_listener.rs
@@ -76,21 +76,14 @@ fn send_current_input_states(
     pin_descriptions: &[PinDescription; 40],
     connected_hardware: &dyn Hardware,
 ) {
-    println!("Scanning for input pins");
     // Send initial levels
     for (board_pin_number, pin_function) in &config.configured_pins {
         if let PinFunction::Input(_pullup) = pin_function {
-            println!("Found input pin #{}", board_pin_number);
             if let Some(bcm_pin_number) =
                 pin_descriptions[*board_pin_number as usize - 1].bcm_pin_number
             {
-                println!("Pin has bcm number: {}", bcm_pin_number);
                 // Update UI with initial state
                 if let Ok(initial_level) = connected_hardware.get_input_level(bcm_pin_number) {
-                    println!(
-                        "Read initial level: {} and sending to listener",
-                        initial_level
-                    );
                     let _ = tx.try_send(InputLevelChanged(LevelChange::new(
                         bcm_pin_number,
                         initial_level,

--- a/src/hw_listener.rs
+++ b/src/hw_listener.rs
@@ -15,6 +15,8 @@ use crate::hw_listener::HardwareEvent::{
 };
 
 /// This enum is for events created by this listener, sent to the Gui
+// TODO pass PinDescriptions as a reference and handle lifetimes - clone on reception
+#[allow(clippy::large_enum_variant)] // remove when fix todo above
 #[derive(Clone, Debug)]
 pub enum HWListenerEvent {
     /// This listener event indicates that the listener is ready. It conveys a sender to the GUI
@@ -22,7 +24,7 @@ pub enum HWListenerEvent {
     Ready(
         Sender<HardwareEvent>,
         HardwareDescriptor,
-        [PinDescription; 40], // TODO pass as a reference and handle lifetimes - clone on reception
+        [PinDescription; 40],
     ),
     InputChange(LevelChange),
 }

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -8,10 +8,9 @@ use iced::{
 };
 
 // Custom Widgets
-use crate::gpio::{GPIOConfig, PinFunction};
-use crate::hw::Hardware;
+use crate::gpio::{GPIOConfig, PinDescription, PinFunction};
 use crate::hw::HardwareDescriptor;
-use crate::hw_listener::{HardwareEvent, ListenerEvent};
+use crate::hw_listener::{HardwareEvent, HWListenerEvent};
 // Importing pin layout views
 use crate::pin_layout::{logical_pin_view, physical_pin_view};
 
@@ -65,25 +64,23 @@ fn main() -> Result<(), iced::Error> {
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Activate,
+    Activate(u8),
     PinFunctionSelected(usize, PinFunction),
     LayoutChanged(Layout),
     ConfigLoaded((String, GPIOConfig)),
     None,
-    HardwareListener(ListenerEvent),
+    HardwareListener(HWListenerEvent),
 }
 
 pub struct Gpio {
     #[allow(dead_code)]
     config_filename: Option<String>,
     gpio_config: GPIOConfig,
-    config_changed: bool,
-    connected_hardware: Box<dyn Hardware>,
-    pub pin_function_selected: Vec<Option<PinFunction>>,
-    clicked: bool,
+    pub pin_function_selected: [Option<PinFunction>; 40],
     chosen_layout: Layout,
-    hardware_description: HardwareDescriptor,
+    hardware_description: Option<HardwareDescriptor>,
     listener_sender: Option<Sender<HardwareEvent>>,
+    pin_descriptions: Option<[PinDescription; 40]>,
 }
 
 impl Gpio {
@@ -97,19 +94,12 @@ impl Gpio {
         }
     }
 
-    fn update_hw_listener_config(&mut self) {
-        // Since config loading and hardware listener setup can occur out of order
-        // track if there has been a config change made that is pending to send to
-        // the hw_listener, and if so, send it
-        if self.config_changed {
-            if let Some(ref mut listener) = &mut self.listener_sender {
-                let _ = listener.try_send(HardwareEvent::HardwareConfigured(
-                    self.gpio_config.clone(),
-                    Box::new(self.connected_hardware.pin_descriptions()),
-                ));
-                self.config_changed = false;
-            }
-        }
+    // A new function has been selected for a pin via the UI
+    fn new_pin_function(&mut self, pin_number: usize, pin_function: PinFunction) {
+        // TODO let previous_function = self.pin_function_selected[pin_number - 1];
+        self.pin_function_selected[pin_number - 1] = Some(pin_function);
+        // TODO send this as a message to hw listener
+        // TODO        self.new_hw_pin_function(pin_number, previous_function, pin_function);
     }
 }
 
@@ -120,22 +110,15 @@ impl Application for Gpio {
     type Flags = ();
 
     fn new(_flags: ()) -> (Gpio, Command<Self::Message>) {
-        let hw = hw::get();
-        let num_pins = hw.pin_descriptions().len();
-        let pin_function_selected = vec![None; num_pins];
-        let hardware_description = hw.descriptor().unwrap();
-
         (
             Self {
                 config_filename: None,
                 gpio_config: GPIOConfig::default(),
-                config_changed: false,
-                pin_function_selected,
-                clicked: false,
+                pin_function_selected: [None; 40],
                 chosen_layout: Layout::Physical,
-                connected_hardware: Box::new(hw),
-                hardware_description,
-                listener_sender: None,
+                hardware_description: None, // Until listener is ready
+                listener_sender: None,      // Until listener is ready
+                pin_descriptions: None,     // Until listener is ready
             },
             Command::perform(Self::load(env::args().nth(1)), |result| match result {
                 Ok(Some((filename, config))) => Message::ConfigLoaded((filename, config)),
@@ -150,43 +133,9 @@ impl Application for Gpio {
 
     fn update(&mut self, message: Message) -> Command<Self::Message> {
         match message {
-            Message::Activate => self.clicked = true,
+            Message::Activate(pin_number) => println!("Pin {pin_number} clicked"),
             Message::PinFunctionSelected(pin_number, pin_function) => {
-                let previous_function = self.pin_function_selected[pin_number - 1];
-                self.pin_function_selected[pin_number - 1] = Some(pin_function);
-                if let Some(bcm_pin_number) =
-                    self.connected_hardware.pin_descriptions()[pin_number - 1].bcm_pin_number
-                {
-                    // TODO error reporting if config cannot be applied
-                    let _ = self
-                        .connected_hardware
-                        .apply_pin_config(bcm_pin_number, &pin_function);
-                    self.config_changed = true;
-
-                    // Report config changes to the hardware listener
-                    // Since config loading and hardware listener setup can occur out of order
-                    // mark the config as changed. If we send to the listener, then mark as done
-                    match (previous_function, pin_function) {
-                        (Some(PinFunction::Input(_)), PinFunction::Input(_)) => { /* No change */ }
-                        (Some(PinFunction::Input(_)), _) => {
-                            // was an input, not anymore
-                            if let Some(ref mut listener) = &mut self.listener_sender {
-                                let _ = listener
-                                    .try_send(HardwareEvent::InputPinRemoved(bcm_pin_number));
-                                self.config_changed = false;
-                            }
-                        }
-                        (_, PinFunction::Input(_)) => {
-                            // was not an input, is now
-                            if let Some(ref mut listener) = &mut self.listener_sender {
-                                let _ =
-                                    listener.try_send(HardwareEvent::InputPinAdded(bcm_pin_number));
-                                self.config_changed = false;
-                            }
-                        }
-                        (_, _) => { /* Don't care! */ }
-                    }
-                }
+                self.new_pin_function(pin_number, pin_function);
             }
             Message::LayoutChanged(layout) => {
                 self.chosen_layout = layout;
@@ -194,10 +143,7 @@ impl Application for Gpio {
             Message::ConfigLoaded((filename, config)) => {
                 self.config_filename = Some(filename);
                 // TODO error reporting if config cannot be applied
-                self.connected_hardware.apply_config(&config).unwrap();
                 self.gpio_config = config.clone();
-
-                self.config_changed = true;
 
                 for (pin_number, pin_function) in config.configured_pins.iter() {
                     self.pin_function_selected[*pin_number as usize - 1] = Some(*pin_function);
@@ -208,11 +154,14 @@ impl Application for Gpio {
 
             Message::None => {}
             Message::HardwareListener(event) => match event {
-                ListenerEvent::Ready(config_change_sender) => {
+                HWListenerEvent::Ready(config_change_sender, hw_desc, pins) => {
                     self.listener_sender = Some(config_change_sender);
-                    self.update_hw_listener_config();
+                    self.hardware_description = Some(hw_desc);
+                    self.pin_descriptions = Some(pins);
+                    // TODO send as a message to hw listener
+                    // TODO                self.update_hw_listener_config();
                 }
-                ListenerEvent::InputChange(level_change) => {
+                HWListenerEvent::InputChange(level_change) => {
                     println!("Input changed: {:?}", level_change);
                 }
             },
@@ -229,49 +178,49 @@ impl Application for Gpio {
         .text_size(25)
         .placeholder("Choose Layout");
 
-        let pin_layout = match self.chosen_layout {
-            Layout::Physical => physical_pin_view(
-                &self.connected_hardware.pin_descriptions(),
-                &self.gpio_config,
-                self,
-            ),
-            Layout::Logical => logical_pin_view(
-                &self.connected_hardware.pin_descriptions(),
-                &self.gpio_config,
-                self,
-            ),
-        };
-        let layout_row = Row::new()
-            .push(layout_selector)
-            .align_items(Alignment::Center)
-            .spacing(10);
+        let mut main_row = Row::new();
 
-        let hardware_desc_row = Row::new()
-            .push(hardware_view(&self.hardware_description))
-            .align_items(Alignment::Start);
+        if let Some(hw_desc) = &self.hardware_description {
+            let layout_row = Row::new()
+                .push(layout_selector)
+                .align_items(Alignment::Center)
+                .spacing(10);
 
-        let main_column = Row::new()
-            .push(
+            let hardware_desc_row = Row::new()
+                .push(hardware_view(hw_desc))
+                .align_items(Alignment::Start);
+
+            main_row = main_row.push(
                 Column::new()
                     .push(layout_row)
                     .push(hardware_desc_row)
                     .align_items(Alignment::Center)
                     .width(Length::Fixed(400.0))
                     .spacing(10),
-            )
-            .push(
-                Column::new()
-                    .push(pin_layout)
-                    .spacing(10)
-                    .align_items(Alignment::Center)
-                    .width(Length::Fixed(700.0))
-                    .height(Length::Fill),
-            )
-            .align_items(Alignment::Start)
-            .width(Length::Fill)
-            .height(Length::Fill);
+            );
+        }
 
-        container(main_column)
+        if let Some(pins) = &self.pin_descriptions {
+            let pin_layout = match self.chosen_layout {
+                Layout::Physical => physical_pin_view(pins, &self.gpio_config, self),
+                Layout::Logical => logical_pin_view(pins, &self.gpio_config, self),
+            };
+
+            main_row = main_row
+                .push(
+                    Column::new()
+                        .push(pin_layout)
+                        .spacing(10)
+                        .align_items(Alignment::Center)
+                        .width(Length::Fixed(700.0))
+                        .height(Length::Fill),
+                )
+                .align_items(Alignment::Start)
+                .width(Length::Fill)
+                .height(Length::Fill);
+        }
+
+        container(main_row)
             .height(Length::Fill)
             .width(Length::Fill)
             .padding(30)

--- a/src/piglet.rs
+++ b/src/piglet.rs
@@ -1,6 +1,7 @@
 use hw::Hardware;
 
 mod gpio;
+#[allow(dead_code)]
 mod hw;
 
 fn main() {

--- a/src/pin_layout.rs
+++ b/src/pin_layout.rs
@@ -107,20 +107,17 @@ pub fn physical_pin_view(
                     if let Some(bcm_pin_number) = pair[0].bcm_pin_number {
                         // If the pin number matches the BCM number, use the configured pin function
                         if *pin_number == bcm_pin_number {
-                            Some(pin_function.clone())
+                            Some(*pin_function)
                         } else {
                             // If not, then use the pin function selected from the UI
                             gpio.pin_function_selected[pair[0].board_pin_number as usize - 1]
-                                .clone()
                         }
                     } else {
                         // If the pin does not have a BCM number, use the pin function selected from the UI
-                        gpio.pin_function_selected[pair[0].board_pin_number as usize - 1].clone()
+                        gpio.pin_function_selected[pair[0].board_pin_number as usize - 1]
                     }
                 })
-                .or_else(|| {
-                    gpio.pin_function_selected[pair[0].board_pin_number as usize - 1].clone()
-                }),
+                .or_else(|| gpio.pin_function_selected[pair[0].board_pin_number as usize - 1]),
             true,
         );
 
@@ -134,21 +131,18 @@ pub fn physical_pin_view(
                     if let Some(bcm_pin_number) = pair[1].bcm_pin_number {
                         // If the pin number matches the BCM number, use the configured pin function
                         if *pin_number == bcm_pin_number {
-                            Some(pin_function.clone())
+                            Some(*pin_function)
                         } else {
                             // If not, then use the pin function selected from the UI
                             gpio.pin_function_selected[pair[1].board_pin_number as usize - 1]
-                                .clone()
                         }
                     } else {
                         // If the pin does not have a BCM number, use the pin function selected from the UI
-                        gpio.pin_function_selected[pair[1].board_pin_number as usize - 1].clone()
+                        gpio.pin_function_selected[pair[1].board_pin_number as usize - 1]
                     }
                 })
                 // If no configured pin function found, fallback to the pin function selected from the UI
-                .or_else(|| {
-                    gpio.pin_function_selected[pair[1].board_pin_number as usize - 1].clone()
-                }),
+                .or_else(|| gpio.pin_function_selected[pair[1].board_pin_number as usize - 1]),
             false,
         );
 

--- a/src/pin_layout.rs
+++ b/src/pin_layout.rs
@@ -1,11 +1,11 @@
-use iced::widget::{button, container, pick_list, Column, Row, Text};
 use iced::{Alignment, Color, Element, Length};
+use iced::widget::{button, Column, container, pick_list, Row, Text};
 
 use crate::custom_widgets::{circle::circle, line::line};
 use crate::gpio::{GPIOConfig, PinDescription, PinFunction};
-use crate::style::CustomButton;
 use crate::Gpio;
 use crate::Message;
+use crate::style::CustomButton;
 
 fn get_pin_color(pin_description: &PinDescription) -> CustomButton {
     match pin_description.name {
@@ -241,7 +241,7 @@ fn create_pin_view_side(
             .padding(10)
             .width(Length::Fixed(40f32))
             .style(pin_color.get_button_style())
-            .on_press(Message::Activate),
+            .on_press(Message::Activate(pin.board_pin_number)),
     );
     pin_button = pin_button.push(pin_button_row);
 


### PR DESCRIPTION
Fixes #78

It also moves all real HW handling to the HW listener, and removes holding of "hw" struct in piggui.rs

When hardware is detected/configured, then the hw_listener sends information back to piggui that it can use to draw the UI.

Until then the UI cannot be drawn and is blank. But for current implementation this is almost immediate at startup and it's not noticable.

If we want to later do connection to remote HW, then some connection means will be needed, and the pin layout and hw layout will not be drawn until we know more about the HW we have connected to it - facilitated by the hw_listener.