### PR TITLE
Commit formatting changes after running cargo fmt on project.

### DIFF
--- a/src/custom_widgets/button_style.rs
+++ b/src/custom_widgets/button_style.rs
@@ -1,5 +1,5 @@
-use iced::{Color, Theme};
 use iced::widget::button;
+use iced::{Color, Theme};
 
 pub struct ButtonStyle {
     pub bg_color: Color,

--- a/src/custom_widgets/circle.rs
+++ b/src/custom_widgets/circle.rs
@@ -1,8 +1,8 @@
-use iced::{Color, Element, Length, Rectangle, Size};
 use iced::advanced::layout::{self, Layout};
 use iced::advanced::renderer;
 use iced::advanced::widget::{self, Widget};
 use iced::mouse;
+use iced::{Color, Element, Length, Rectangle, Size};
 
 pub struct Circle {
     radius: f32,

--- a/src/custom_widgets/clicker.rs
+++ b/src/custom_widgets/clicker.rs
@@ -1,8 +1,8 @@
-use iced::{Color, Element, Length, Rectangle, Size};
 use iced::advanced::layout::{self, Layout};
 use iced::advanced::renderer;
 use iced::advanced::widget::{self, Widget};
 use iced::mouse;
+use iced::{Color, Element, Length, Rectangle, Size};
 
 pub struct Clicker {
     radius: f32,

--- a/src/custom_widgets/led.rs
+++ b/src/custom_widgets/led.rs
@@ -1,8 +1,8 @@
-use iced::{Color, Element, Length, Rectangle, Size};
 use iced::advanced::layout::{self, Layout};
 use iced::advanced::renderer;
 use iced::advanced::widget::{self, Widget};
 use iced::mouse;
+use iced::{Color, Element, Length, Rectangle, Size};
 
 use crate::hw::PinLevel;
 

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -341,9 +341,9 @@ mod test {
     use tempfile::tempdir;
 
     use crate::hw;
-    use crate::hw::{GPIOConfig, LevelChange, PinFunction};
     use crate::hw::Hardware;
     use crate::hw::InputPull::PullUp;
+    use crate::hw::{GPIOConfig, LevelChange, PinFunction};
 
     #[test]
     fn hw_can_be_got() {

--- a/src/hw/pi.rs
+++ b/src/hw/pi.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::fs;
 use std::io;
 
+use rppal::gpio::Gpio;
+use rppal::gpio::OutputPin;
 /// Implementation of GPIO for raspberry pi - uses rrpal
 #[allow(unused_imports)] // just checking builds work for now...
 use rppal::gpio::{InputPin, Level, Trigger};
-use rppal::gpio::Gpio;
-use rppal::gpio::OutputPin;
 
 use crate::hw::{BCMPinNumber, GPIOConfig, LevelChange, PinDescriptionSet, PinLevel};
 use crate::hw::{InputPull, PinFunction};

--- a/src/hw_listener.rs
+++ b/src/hw_listener.rs
@@ -1,14 +1,14 @@
-use iced::{subscription, Subscription};
 use iced::futures::channel::mpsc;
 use iced::futures::channel::mpsc::Sender;
+use iced::{subscription, Subscription};
 use iced_futures::futures::sink::SinkExt;
 use iced_futures::futures::StreamExt;
 
 use crate::hw;
 use crate::hw::{BCMPinNumber, GPIOConfig, LevelChange, PinDescriptionSet, PinFunction};
 use crate::hw::{Hardware, HardwareDescriptor};
-use crate::hw_listener::HardwareEvent::{InputLevelChanged, NewConfig, NewPinConfig};
 use crate::hw_listener::HWListenerEvent::InputChange;
+use crate::hw_listener::HardwareEvent::{InputLevelChanged, NewConfig, NewPinConfig};
 
 /// This enum is for events created by this listener, sent to the Gui
 // TODO pass PinDescriptions as a reference and handle lifetimes - clone on reception

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -1,22 +1,22 @@
-use std::{env, io};
 use std::time::Duration;
+use std::{env, io};
 
-use iced::{
-    Alignment, Application, Color, Command, Element, executor, Length, Settings, Subscription,
-    Theme, window,
-};
 use iced::futures::channel::mpsc::Sender;
-use iced::widget::{Button, Column, container, pick_list, Row, Text};
+use iced::widget::{container, pick_list, Button, Column, Row, Text};
+use iced::{
+    executor, window, Alignment, Application, Color, Command, Element, Length, Settings,
+    Subscription, Theme,
+};
 
 use custom_widgets::button_style::ButtonStyle;
 use custom_widgets::toast::{self, Manager, Status, Toast};
 use hw::{BCMPinNumber, BoardPinNumber, GPIOConfig, HardwareDescriptor, PinFunction};
-use hw_listener::{HardwareEvent, HWListenerEvent};
+use hw_listener::{HWListenerEvent, HardwareEvent};
 use pin_layout::{bcm_pin_layout_view, board_pin_layout_view};
 
 use crate::hw::{LevelChange, PinDescriptionSet};
 use crate::layout::Layout;
-use crate::pin_state::{CHART_UPDATES_PER_SECOND, PinState};
+use crate::pin_state::{PinState, CHART_UPDATES_PER_SECOND};
 use crate::version::version;
 use crate::views::hardware::hardware_view;
 

--- a/src/pin_layout.rs
+++ b/src/pin_layout.rs
@@ -1,23 +1,23 @@
-use iced::{Alignment, Color, Element, Length};
 use iced::advanced::text::editor::Direction;
 use iced::alignment::Horizontal;
-use iced::widget::{button, Column, horizontal_space, pick_list, Row, Text, toggler};
 use iced::widget::mouse_area;
+use iced::widget::{button, horizontal_space, pick_list, toggler, Column, Row, Text};
+use iced::{Alignment, Color, Element, Length};
 
-use crate::{Gpio, PinState};
-use crate::custom_widgets::{circle::circle, line::line};
 use crate::custom_widgets::button_style::ButtonStyle;
 use crate::custom_widgets::clicker::clicker;
 use crate::custom_widgets::led::led;
 use crate::custom_widgets::toggler_style::TogglerStyle;
+use crate::custom_widgets::{circle::circle, line::line};
+use crate::hw::InputPull;
+use crate::hw::PinFunction::{Input, Output};
 use crate::hw::{
     BCMPinNumber, BoardPinNumber, LevelChange, PinDescription, PinDescriptionSet, PinFunction,
     PinLevel,
 };
-use crate::hw::InputPull;
-use crate::hw::PinFunction::{Input, Output};
-use crate::Message;
 use crate::pin_state::CHART_WIDTH;
+use crate::Message;
+use crate::{Gpio, PinState};
 
 // WIDTHS
 const PIN_BUTTON_WIDTH: f32 = 30.0;

--- a/src/pin_state.rs
+++ b/src/pin_state.rs
@@ -5,8 +5,8 @@ use iced::Element;
 use plotters::prelude::{RGBAColor, ShapeStyle};
 
 use crate::hw::{LevelChange, PinLevel};
-use crate::Message;
 use crate::views::waveform::{ChartType, Waveform};
+use crate::Message;
 
 pub const CHART_UPDATES_PER_SECOND: u64 = 4;
 pub const CHART_WIDTH: f32 = 256.0;

--- a/src/views/waveform.rs
+++ b/src/views/waveform.rs
@@ -1,14 +1,14 @@
-use std::{collections::VecDeque, time::Duration};
 use std::cell::RefCell;
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
+use std::{collections::VecDeque, time::Duration};
 
 use chrono::{DateTime, Utc};
-use iced::{
-    Element,
-    Length, Size, widget::canvas::{Cache, Frame, Geometry},
-};
 use iced::advanced::text::editor::Direction;
+use iced::{
+    widget::canvas::{Cache, Frame, Geometry},
+    Element, Length, Size,
+};
 use plotters::backend::DrawingBackend;
 use plotters::chart::ChartBuilder;
 use plotters::series::LineSeries;
@@ -16,8 +16,8 @@ use plotters::style::ShapeStyle;
 use plotters_iced::{Chart, ChartWidget, Renderer};
 
 use crate::hw::{LevelChange, PinLevel};
-use crate::Message;
 use crate::views::waveform::ChartType::{Squarewave, Verbatim};
+use crate::Message;
 
 /// `Sample<T>` can be used to send new samples to a waveform widget for display in a moving chart
 /// It must have a type `T` that implements `Into<u32>` for Y-axis value, and a `DateTime` when it


### PR DESCRIPTION
Avoid running "Organize imports" in the IDE, as rustfmt reformats imports also.
This re-committs these files after running cargo fmt on the project.