### PR TITLE
Add status to bar

### DIFF
--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -333,10 +333,11 @@ impl GPIOConfig {
 
     /// Save this GPIOConfig to the file named `filename`
     #[allow(dead_code)]
-    pub fn save(&self, filename: &str) -> io::Result<()> {
+    pub fn save(&self, filename: &str) -> io::Result<String> {
         let mut file = File::create(filename)?;
         let contents = serde_json::to_string(self)?;
-        file.write_all(contents.as_bytes())
+        file.write_all(contents.as_bytes())?;
+        Ok(format!("File saved successfully to {}", filename))
     }
     pub fn is_equal(&self, other: &Self) -> bool {
         self.configured_pins == other.configured_pins

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -2,8 +2,9 @@ use iced::Size;
 
 // use crate::pin_layout::{BCM_PIN_LAYOUT_WIDTH, BOARD_PIN_LAYOUT_WIDTH};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Layout {
+    #[default]
     BoardLayout,
     BCMLayout,
 }

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -20,7 +20,8 @@ use crate::hw::{hw_listener, LevelChange};
 use crate::layout::Layout;
 use crate::pin_state::{PinState, CHART_UPDATES_PER_SECOND};
 use crate::views::hardware::hw_description;
-use crate::views::info::{info_row, StatusMessage, StatusMessageQueue};
+use crate::views::info::info_row;
+use crate::views::status::{StatusMessage, StatusMessageQueue};
 use crate::views::version::version;
 
 mod custom_widgets;

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -545,7 +545,8 @@ impl Application for Gpio {
             iced::event::listen().map(Message::WindowEvent),
         ];
 
-        if self.status_message_queue.has_info_messages() {
+        if self.status_message_queue.showing_info_message() {
+            println!("Will clear info message in 3s");
             subscriptions.push(
                 iced::time::every(Duration::from_secs(3)).map(|_| Message::ClearStatusMessage),
             );

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -4,7 +4,7 @@ use std::{env, io};
 use iced::futures::channel::mpsc::Sender;
 use iced::widget::{container, pick_list, Button, Column, Row, Text};
 use iced::{
-    executor, window, Alignment, Application, Color, Command, Element, Length, Padding, Settings,
+    executor, window, Alignment, Application, Color, Command, Element, Length, Settings,
     Subscription, Theme,
 };
 
@@ -514,20 +514,13 @@ impl Application for Gpio {
     fn view(&self) -> Element<Self::Message> {
         let main_col = Column::new().push(self.main_row()).push(info_row(self));
 
-        let padding = Padding {
-            top: 10.0,
-            right: 10.0,
-            bottom: 0.0,
-            left: 10.0,
-        };
-
         let content = container(main_col)
             .height(Length::Fill)
             .width(Length::Fill)
             .align_x(iced::alignment::Horizontal::Center)
             .center_x()
             .center_y()
-            .padding(padding);
+            .padding([10.0, 10.0, 0.0, 10.0]);
 
         Manager::new(content, &self.toasts, |index| {
             Message::Toast(ToastMessage::Close(index))

--- a/src/views/info.rs
+++ b/src/views/info.rs
@@ -1,13 +1,33 @@
+use crate::custom_widgets::button_style::ButtonStyle;
 use crate::views::hardware::hardware_button;
 use crate::views::version::version_button;
 use crate::{Gpio, Message};
+use iced::widget::button;
 use iced::widget::Row;
-use iced::Element;
+use iced::{Color, Element};
+
+fn status_message(app: &Gpio) -> Element<Message> {
+    let button_style = ButtonStyle {
+        bg_color: Color::TRANSPARENT,
+        text_color: Color::WHITE,
+        hovered_bg_color: Color::TRANSPARENT,
+        hovered_text_color: Color::new(0.7, 0.7, 0.7, 1.0),
+        border_radius: 4.0,
+    };
+
+    match app.unsaved_changes {
+        true => button("Unsaved changes").on_press(Message::Save),
+        false => button("            "),
+    }
+    .style(button_style.get_button_style())
+    .into()
+}
 
 pub fn info_row(app: &Gpio) -> Element<Message> {
     Row::new()
         .push(version_button(app))
         .push(hardware_button(app))
+        .push(status_message(app))
         .spacing(20.0)
         .into()
 }

--- a/src/views/info.rs
+++ b/src/views/info.rs
@@ -2,9 +2,44 @@ use crate::custom_widgets::button_style::ButtonStyle;
 use crate::views::hardware::hardware_button;
 use crate::views::version::version_button;
 use crate::{Gpio, Message};
-use iced::widget::button;
-use iced::widget::Row;
-use iced::{Color, Element};
+use iced::widget::{Button, Row, Text};
+use iced::{Color, Element, Length};
+
+/// There are three types of messages we can display in the message text in the status bar
+/// * Error - with an associated long message and a boolean that determines if user must cancel to remove it
+/// * Warning - will disappear after a period
+/// * Info - will disappear after a period
+#[derive(Debug, Clone)]
+pub enum StatusMessage {
+    Error(String, String, bool),
+    Warning(String),
+    Info(String),
+}
+
+impl StatusMessage {
+    fn text(&self) -> String {
+        match self {
+            StatusMessage::Error(msg, _, _) => msg.clone(),
+            StatusMessage::Warning(msg) => msg.clone(),
+            StatusMessage::Info(msg) => msg.clone(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct StatusMessageQueue {
+    messages: Vec<StatusMessage>,
+}
+
+impl StatusMessageQueue {
+    pub fn add(&mut self, message: StatusMessage) {
+        self.messages.push(message)
+    }
+
+    pub fn peek(&self) -> Option<&StatusMessage> {
+        self.messages.last()
+    }
+}
 
 fn status_message(app: &Gpio) -> Element<Message> {
     let button_style = ButtonStyle {
@@ -15,10 +50,32 @@ fn status_message(app: &Gpio) -> Element<Message> {
         border_radius: 4.0,
     };
 
+    let message = app
+        .status_message_queue
+        .peek()
+        .map(|msg| msg.text())
+        .unwrap_or("".into());
+
+    Button::new(Text::new(message))
+        .style(button_style.get_button_style())
+        .width(Length::Fixed(400.0))
+        .into()
+}
+
+fn unsaved_status(app: &Gpio) -> Element<Message> {
+    let button_style = ButtonStyle {
+        bg_color: Color::TRANSPARENT,
+        text_color: Color::WHITE,
+        hovered_bg_color: Color::TRANSPARENT,
+        hovered_text_color: Color::new(0.7, 0.7, 0.7, 1.0),
+        border_radius: 4.0,
+    };
+
     match app.unsaved_changes {
-        true => button("Unsaved changes").on_press(Message::Save),
-        false => button("            "),
+        true => Button::new("Unsaved changes").on_press(Message::Save),
+        false => Button::new(""),
     }
+    .width(Length::Fixed(140.0))
     .style(button_style.get_button_style())
     .into()
 }
@@ -27,6 +84,7 @@ pub fn info_row(app: &Gpio) -> Element<Message> {
     Row::new()
         .push(version_button(app))
         .push(hardware_button(app))
+        .push(unsaved_status(app))
         .push(status_message(app))
         .spacing(20.0)
         .into()

--- a/src/views/info.rs
+++ b/src/views/info.rs
@@ -1,66 +1,10 @@
 use crate::custom_widgets::button_style::ButtonStyle;
 use crate::views::hardware::hardware_button;
+use crate::views::status::status_message;
 use crate::views::version::version_button;
 use crate::{Gpio, Message};
-use iced::widget::{Button, Row, Text};
+use iced::widget::{Button, Row};
 use iced::{Color, Element, Length};
-
-/// There are three types of messages we can display in the message text in the status bar
-/// * Error - with an associated long message and a boolean that determines if user must cancel to remove it
-/// * Warning - will disappear after a period
-/// * Info - will disappear after a period
-#[derive(Debug, Clone)]
-pub enum StatusMessage {
-    Error(String, String, bool),
-    Warning(String),
-    Info(String),
-}
-
-impl StatusMessage {
-    fn text(&self) -> String {
-        match self {
-            StatusMessage::Error(msg, _, _) => msg.clone(),
-            StatusMessage::Warning(msg) => msg.clone(),
-            StatusMessage::Info(msg) => msg.clone(),
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct StatusMessageQueue {
-    messages: Vec<StatusMessage>,
-}
-
-impl StatusMessageQueue {
-    pub fn add(&mut self, message: StatusMessage) {
-        self.messages.push(message)
-    }
-
-    pub fn peek(&self) -> Option<&StatusMessage> {
-        self.messages.last()
-    }
-}
-
-fn status_message(app: &Gpio) -> Element<Message> {
-    let button_style = ButtonStyle {
-        bg_color: Color::TRANSPARENT,
-        text_color: Color::WHITE,
-        hovered_bg_color: Color::TRANSPARENT,
-        hovered_text_color: Color::new(0.7, 0.7, 0.7, 1.0),
-        border_radius: 4.0,
-    };
-
-    let message = app
-        .status_message_queue
-        .peek()
-        .map(|msg| msg.text())
-        .unwrap_or("".into());
-
-    Button::new(Text::new(message))
-        .style(button_style.get_button_style())
-        .width(Length::Fixed(400.0))
-        .into()
-}
 
 fn unsaved_status(app: &Gpio) -> Element<Message> {
     let button_style = ButtonStyle {

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,4 +1,5 @@
 pub mod hardware;
 pub mod info;
+pub mod status;
 pub mod version;
 pub mod waveform;

--- a/src/views/status.rs
+++ b/src/views/status.rs
@@ -1,4 +1,5 @@
 use crate::custom_widgets::button_style::ButtonStyle;
+use crate::views::status::StatusMessage::Info;
 use crate::{Gpio, Message};
 use iced::widget::{Button, Text};
 use iced::{Color, Element, Length};
@@ -54,6 +55,7 @@ impl StatusMessageQueue {
     /// If there is another message in the queue then it sets that as the new message to be shown
     /// If there is no other message queues to be shown, then set to None and no message is shown
     pub fn clear_message(&mut self) {
+        println!("Clearing message");
         if self.queue.is_empty() {
             self.current_message = None;
         } else {
@@ -62,8 +64,12 @@ impl StatusMessageQueue {
     }
 
     /// Are there any [StatusMessage]  of type Info in the queue waiting to be displayed?
-    pub fn has_info_messages(&self) -> bool {
-        !self.queue.is_empty()
+    pub fn showing_info_message(&self) -> bool {
+        if let Some(Info(_)) = self.current_message {
+            true
+        } else {
+            false
+        }
     }
 }
 
@@ -112,7 +118,7 @@ mod test {
         queue.add_message(Warning("middle".into()));
         assert_eq!(queue.queue.len(), 3);
 
-        assert!(queue.has_info_messages());
+        assert!(queue.showing_info_message());
 
         queue.clear_message();
         assert_eq!(

--- a/src/views/status.rs
+++ b/src/views/status.rs
@@ -3,21 +3,27 @@ use crate::{Gpio, Message};
 use iced::widget::{Button, Text};
 use iced::{Color, Element, Length};
 
-/// There are three types of messages we can display in the message text in the status bar
-/// * Error - with an associated long message and a boolean that determines if user must cancel to remove it
-/// * Warning - will disappear after a period
-/// * Info - will disappear after a period
-#[derive(Debug, Clone)]
+/// There are three types of messages we can display in the message text in the status bar.
+///
+/// They are (in order of priority - highest to lowest):
+/// * Error -  will remain until clicked
+/// * Warning - will remain until clicked
+/// * Info - will disappear after a short time
+///
+/// Messages of higher priority are shown before those of lower priority.
+/// Clicking a message removes it and shows next message.
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u8)]
 pub enum StatusMessage {
-    Error(String, String, bool),
-    Warning(String),
-    Info(String),
+    Info(String) = 0,
+    Warning(String) = 1,
+    Error(String, String) = 2,
 }
 
 impl StatusMessage {
     fn text(&self) -> String {
         match self {
-            StatusMessage::Error(msg, _, _) => msg.clone(),
+            StatusMessage::Error(msg, _) => msg.clone(),
             StatusMessage::Warning(msg) => msg.clone(),
             StatusMessage::Info(msg) => msg.clone(),
         }
@@ -26,36 +32,92 @@ impl StatusMessage {
 
 #[derive(Default)]
 pub struct StatusMessageQueue {
-    messages: Vec<StatusMessage>,
+    queue: Vec<StatusMessage>,
+    current_message: Option<StatusMessage>,
 }
 
 impl StatusMessageQueue {
-    pub fn add(&mut self, message: StatusMessage) {
-        self.messages.push(message)
+    /// Add a new [StatusMessage] to be displayed
+    /// If none is being displayed currently, set it as the one that will be displayed by view().
+    /// If a message is currently being displayed, add this one to the queue.
+    pub fn add_message(&mut self, message: StatusMessage) {
+        match self.current_message {
+            None => self.current_message = Some(message),
+            Some(_) => {
+                self.queue.push(message);
+                self.queue.sort();
+            }
+        }
     }
 
-    pub fn peek(&self) -> Option<&StatusMessage> {
-        self.messages.last()
+    /// Clear the current message being displayed.
+    /// If there is another message in the queue then it sets that as the new message to be shown
+    /// If there is no other message queues to be shown, then set to None and no message is shown
+    pub fn clear_message(&mut self) {
+        if self.queue.is_empty() {
+            self.current_message = None;
+        } else {
+            self.current_message = self.queue.pop();
+        }
+    }
+
+    /// Are there any [StatusMessage]  of type Info in the queue waiting to be displayed?
+    pub fn has_info_messages(&self) -> bool {
+        !self.queue.is_empty()
     }
 }
 
 pub fn status_message(app: &Gpio) -> Element<Message> {
+    let (text_color, message_text) = match &app.status_message_queue.current_message {
+        None => (Color::TRANSPARENT, "".into()),
+        Some(msg) => {
+            let text_color = match msg {
+                StatusMessage::Error(_, _) => Color::from_rgb8(255, 0, 0),
+                StatusMessage::Warning(_) => iced::Color::new(1.0, 0.647, 0.0, 1.0),
+                StatusMessage::Info(_) => Color::WHITE,
+            };
+            (text_color, msg.text())
+        }
+    };
+
     let button_style = ButtonStyle {
         bg_color: Color::TRANSPARENT,
-        text_color: Color::WHITE,
+        text_color,
         hovered_bg_color: Color::TRANSPARENT,
-        hovered_text_color: Color::new(0.7, 0.7, 0.7, 1.0),
+        hovered_text_color: Color::WHITE,
         border_radius: 4.0,
     };
 
-    let message = app
-        .status_message_queue
-        .peek()
-        .map(|msg| msg.text())
-        .unwrap_or("".into());
-
-    Button::new(Text::new(message))
+    Button::new(Text::new(message_text))
+        .on_press(Message::ClearStatusMessage)
         .style(button_style.get_button_style())
         .width(Length::Fixed(400.0))
         .into()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::views::status::StatusMessage::{Error, Info, Warning};
+    use crate::views::status::StatusMessageQueue;
+
+    #[test]
+    fn errors_first() {
+        let mut queue: StatusMessageQueue = Default::default();
+
+        queue.add_message(Info("shown".into()));
+        assert_eq!(queue.current_message, Some(Info("shown".into())));
+
+        queue.add_message(Info("last".into()));
+        queue.add_message(Error("first".into(), "Details".into()));
+        queue.add_message(Warning("middle".into()));
+        assert_eq!(queue.queue.len(), 3);
+
+        assert!(queue.has_info_messages());
+
+        queue.clear_message();
+        assert_eq!(
+            queue.current_message,
+            Some(Error("first".into(), "Details".into()))
+        );
+    }
 }

--- a/src/views/status.rs
+++ b/src/views/status.rs
@@ -98,9 +98,7 @@ pub fn status_message(app: &Gpio) -> Element<Message> {
 #[cfg(test)]
 mod test {
     use crate::views::status::StatusMessage::{Error, Info, Warning};
-    use crate::views::status::{status_message, StatusMessageQueue};
-    use crate::Gpio;
-    use iced::application::Application;
+    use crate::views::status::StatusMessageQueue;
 
     #[test]
     fn errors_first() {
@@ -131,16 +129,5 @@ mod test {
         queue.clear_message();
         assert_eq!(queue.current_message, Some(Info("last".into())));
         assert_eq!(queue.queue.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn no_text() {
-        let (app, _command) = Gpio::new(());
-        let el = status_message(&app);
-        let button = el.as_widget();
-        let tree = button.children();
-        println!("{:?}", tree);
-        let text = tree.first();
-        println!("{:?}", text);
     }
 }

--- a/src/views/status.rs
+++ b/src/views/status.rs
@@ -1,0 +1,61 @@
+use crate::custom_widgets::button_style::ButtonStyle;
+use crate::{Gpio, Message};
+use iced::widget::{Button, Text};
+use iced::{Color, Element, Length};
+
+/// There are three types of messages we can display in the message text in the status bar
+/// * Error - with an associated long message and a boolean that determines if user must cancel to remove it
+/// * Warning - will disappear after a period
+/// * Info - will disappear after a period
+#[derive(Debug, Clone)]
+pub enum StatusMessage {
+    Error(String, String, bool),
+    Warning(String),
+    Info(String),
+}
+
+impl StatusMessage {
+    fn text(&self) -> String {
+        match self {
+            StatusMessage::Error(msg, _, _) => msg.clone(),
+            StatusMessage::Warning(msg) => msg.clone(),
+            StatusMessage::Info(msg) => msg.clone(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct StatusMessageQueue {
+    messages: Vec<StatusMessage>,
+}
+
+impl StatusMessageQueue {
+    pub fn add(&mut self, message: StatusMessage) {
+        self.messages.push(message)
+    }
+
+    pub fn peek(&self) -> Option<&StatusMessage> {
+        self.messages.last()
+    }
+}
+
+pub fn status_message(app: &Gpio) -> Element<Message> {
+    let button_style = ButtonStyle {
+        bg_color: Color::TRANSPARENT,
+        text_color: Color::WHITE,
+        hovered_bg_color: Color::TRANSPARENT,
+        hovered_text_color: Color::new(0.7, 0.7, 0.7, 1.0),
+        border_radius: 4.0,
+    };
+
+    let message = app
+        .status_message_queue
+        .peek()
+        .map(|msg| msg.text())
+        .unwrap_or("".into());
+
+    Button::new(Text::new(message))
+        .style(button_style.get_button_style())
+        .width(Length::Fixed(400.0))
+        .into()
+}


### PR DESCRIPTION
Add a field that shows messages momentarily, or errors until cancelled.
Fixes #140 