### PR TITLE
Refactor HardwareView to keep all configured pins in only one struct

### DIFF
--- a/configs/andrews_board.pigg
+++ b/configs/andrews_board.pigg
@@ -1,6 +1,1 @@
-{
-    "configured_pins":[
-    [17,{"Output":true}],
-    [26,{"Input":"PullUp"}]
-    ]
-}
+{"configured_pins":{"26":{"Input":"PullUp"},"17":{"Output":true}}}


### PR DESCRIPTION
Fixes #178 

All config in GPIOConfig, that is a hash map of pins indexed by BCMPinNumber.
Removes duplicate struct, and indexing by board pin number, unused pin configs and pin states