### PR TITLE
feat: Use `tracing_subscriber` for setting up logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,6 +3229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,6 +3522,16 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -3838,6 +3857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,6 +4154,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4700,8 +4727,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4712,7 +4748,7 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -4720,6 +4756,12 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5300,6 +5342,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5832,6 +5883,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6090,6 +6151,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -6275,6 +6366,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ plotters = { version = "0.3", optional = true, default_features = false, feature
     "chrono",
     "line_series",
 ] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing = "0.1.40"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Hi! With this, we retain the actual messages from logging:

```
$ cargo run --bin piglet --features fake_hw -- --verbosity=debug
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `plotters` dependency)
   Compiling pigg v0.2.0 (/home/philipp/program/work/pigg)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.52s
     Running `target/debug/piglet --verbosity=debug`
2024-07-23T08:59:11.743906Z  INFO piglet: 
Hardware: NotAPi
Revision: Unknown
Serial: Unknown
Model: Fake Hardware    
2024-07-23T08:59:11.743995Z  INFO piglet: Default Config loaded    
2024-07-23T08:59:11.745540Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}: iroh_net::magicsock::udp_conn: binding network=V4 port=0
2024-07-23T08:59:11.745609Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}: iroh_net::magicsock::udp_conn: candidate ports ports=[0]
2024-07-23T08:59:11.745634Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}:portmapper.service: iroh_net::portmapper: portmap starting
2024-07-23T08:59:11.745768Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}: iroh_net::magicsock::udp_conn: successfully bound network=V4 local_addr=0.0.0.0:47186
2024-07-23T08:59:11.745811Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}: iroh_net::magicsock::udp_conn: binding network=V6 port=47187
2024-07-23T08:59:11.745830Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}: iroh_net::magicsock::udp_conn: candidate ports ports=[47187, 0]
2024-07-23T08:59:11.745912Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}: iroh_net::magicsock::udp_conn: successfully bound network=V6 local_addr=[::]:47187
2024-07-23T08:59:11.746042Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}:netcheck.actor: iroh_net::netcheck: netcheck actor starting
2024-07-23T08:59:11.747066Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}:portmapper.service: iroh_net::portmapper: getting a port mapping for 192.168.0.99:47186 -> None
2024-07-23T08:59:11.747276Z DEBUG magic_ep{me=lrksf734biryxnax}:magicsock{me=lrksf734biryxnax}:portmapper.service:upnp: igd_next::aio::tokio: sending broadcast request to: 239.255.255.250:1900 on interface: Ok(0.0.0.0:49251)    
```

etc.

With this PR, you can configure the logging using either the `--verbosity=<level>` CLI parameter, or the `RUST_LOG` environment variable.