### PR TITLE
Adds a None option to HardwareTarget and conditionally sets the default

### DIFF
--- a/src/views/info_row.rs
+++ b/src/views/info_row.rs
@@ -69,6 +69,7 @@ impl InfoRow {
             Some(model) => match hardware_target {
                 HardwareTarget::Local => format!("{}@Local", model),
                 HardwareTarget::Remote(_, _) => format!("{}@Remote", model),
+                HardwareTarget::NoHW => "No Hardware connected".to_string(),
             },
         };
 


### PR DESCRIPTION
This adda a NoHW option to Hardware target

- the default if there is no pi_hw and no fake_hw
- allows you to disconnect from local hardware, or remote hardware to "none"