### PR TITLE
Avoid use of features, reduce Makefile and make more standard rust build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,7 +58,6 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo install cross
 
-
       - name: cross
         if: runner.os == 'Linux'
         run: make cross

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,7 +12,7 @@ go away and we will document how you install the binaries directly.
 ### macOS/linux/Windows or Pi (with a fake Hardware backend)
 
 ```
-cargo install pigg --features "fake_hw"
+cargo install pigg
 ```
 
 NOTE: `cargo` will build for the machine where you are running it, so you will get a version of `piggui`
@@ -22,7 +22,7 @@ with a fake hardware backend, not real Pi GPIO hardware, but you can play with t
 
 To be able to interact with real Pi GPIO hardware you have two options:
 
-- Run `cargo install --features "pi_hw"` on your Pi
+- Run `cargo install` on your Pi
 - Follow the instructions before for Building from Source on your Pi
     - Use `make` to build on macOS/linux/Windows and cross-compile for your Pi, but you will need `Docker`/`Podman`
       and `cross` installed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,14 @@ readme = "README.md"
 [[bin]]
 name = "piggui"
 path = "src/piggui.rs"
-required-features = ["gui"]
 
 [[bin]]
 name = "piglet"
 path = "src/piglet.rs"
-required-features = ["hardware"]
 
 [features]
-default = ["gui", "files"]
-pi_hw = ["rppal", "hardware"]
-fake_hw = ["rand", "hardware"]
-gui = ["iced", "iced_futures", "plotters-iced", "plotters", "iced_aw", "lyon_algorithms/default", "once_cell/default"]
-files = ["rfd"]
+default = []
 discovery = []
-hardware = []
 
 [dependencies]
 # use in piggui and piglet
@@ -35,8 +28,8 @@ chrono = { version = "0.4", default-features = false, features = ["now", "serde"
 serde = { version = "1.0.204", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.121", default-features = false, features = ["std"] }
 serde_arrays = "0.1.0"
-clap = { version = "4.5.13", default-features = false, features = ["std"] }
-rand = { version = "0.8.5", optional = true }
+clap = { version = "4.5.11", default-features = false, features = ["std"] }
+rand = { version = "0.8.5" }
 iroh-net = { version = "0.19.0" }
 anyhow = { version = "1" }
 futures-lite = { version = "2.3" }
@@ -52,13 +45,13 @@ service-manager = "0.7.1"
 sysinfo = "0.31.1"
 
 # used by piggui in GUI only
-iced = { version = "0.12.1", default-features = false, features = ["tokio", "debug", "canvas", "advanced"], optional = true }
-iced_aw = { version = "0.9.3", default-features = false, features = ["tabs", "card", "modal", "menu"], optional = true }
-iced_futures = { version = "0.12.0", default-features = false, optional = true }
-iced_native = { version = "0.10.3", default-features = false, optional = true }
+iced = { version = "0.12.1", default-features = false, features = ["tokio", "debug", "canvas", "advanced"] }
+iced_aw = { version = "0.9.3", default-features = false, features = ["tabs", "card", "modal", "menu"] }
+iced_futures = { version = "0.12.0", default-features = false }
+iced_native = { version = "0.10.3", default-features = false }
 rfd = { version = "0.14.1", optional = true }
-plotters-iced = { version = "0.10", default-features = false, optional = true }
-plotters = { version = "0.3", optional = true, default_features = false, features = [
+plotters-iced = { version = "0.10", default-features = false }
+plotters = { version = "0.3", default_features = false, features = [
     "chrono",
     "line_series",
 ] }
@@ -69,3 +62,12 @@ lyon_algorithms = "1.0"
 
 [dev-dependencies]
 tempfile = "3"
+
+[target.'cfg(not(target_arch = "wasm32")'.dependencies]
+rfd = "0.14.1"
+
+[target.aarch64-unknown-linux-gnu.dependencies]
+rppal = "0.18.0"
+
+[target.armv7-unknown-linux-gnueabihf.dependencies]
+rppal = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ iced = { version = "0.12.1", default-features = false, features = ["tokio", "deb
 iced_aw = { version = "0.9.3", default-features = false, features = ["tabs", "card", "modal", "menu"] }
 iced_futures = { version = "0.12.0", default-features = false }
 iced_native = { version = "0.10.3", default-features = false }
-rfd = { version = "0.14.1", optional = true }
 plotters-iced = { version = "0.10", default-features = false }
 plotters = { version = "0.3", default_features = false, features = [
     "chrono",
@@ -63,7 +62,7 @@ lyon_algorithms = "1.0"
 [dev-dependencies]
 tempfile = "3"
 
-[target.'cfg(not(target_arch = "wasm32")'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rfd = "0.14.1"
 
 [target.aarch64-unknown-linux-gnu.dependencies]

--- a/Makefile
+++ b/Makefile
@@ -25,140 +25,64 @@ release: release-build
 
 .PHONY: clippy
 clippy:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	cargo clippy  --bin piggui --tests --no-deps
-	cargo clippy  --bin piglet --tests --no-deps
-else
-	# Compile for host, targeting fake hardware
-	cargo clippy --bin piggui  --tests --no-deps
-	cargo clippy --bin piglet  --tests --no-deps
-endif
+	cargo clippy  --tests --no-deps
 
 # Enable the "iced" feature so we only build the "piggui" binary on the current host (macos, linux or raspberry pi)
 # To build both binaries on a Pi directly, we will need to modify this
 .PHONY: build
 build:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	cargo build --bin piggui 
-	cargo build --bin piglet 
-else
-	# Compile for host, targeting fake hardware
-	cargo build --bin piggui 
-	cargo build --bin piglet 
-endif
+	cargo build
 
 .PHONY: run
 run:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	cargo run --bin piggui 
-else
-	# Compile for host, targeting fake hardware
-	cargo run --bin piggui 
-endif
+	cargo run --bin piggui
 
 .PHONY: run-release
 run-release:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	cargo run --bin piggui --release 
-else
-	# Compile for host, targeting fake hardware
-	cargo run --bin piggui --release 
-endif
+	cargo run --bin piggui --release
 
 .PHONY: run-piglet
 run-piglet:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	RUST_LOG=piglet=info cargo run --bin piglet 
-else
-	# Compile for host, targeting fake hardware
-	RUST_LOG=piglet=info cargo run --bin piglet 
-endif
+	RUST_LOG=piglet=info cargo run --bin piglet
 
 .PHONY: run-release-piglet
 run-release-piglet:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	RUST_LOG=piglet=info cargo run --bin piglet --release 
-else
-	# Compile for host, targeting fake hardware
-	RUST_LOG=piglet=info cargo run --bin piglet --release 
-endif
+	RUST_LOG=piglet=info cargo run --bin piglet --release
 
 # This will build all binaries on the current host, be it macos, linux or raspberry pi - with release profile
-.PHONY: release-build
-release-build:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	cargo build --bin piggui --release 
-	cargo build --bin piglet --release 
-else
-	# Compile for host, targeting fake hardware
-	cargo build --bin piggui --release 
-	cargo build --bin piglet --release 
-endif
+.PHONY: build-release
+build-release:
+	cargo build --release
 
 # This will only test GUI tests in piggui on the local host, whatever that is
 # We'd need to think how to run tests on RPi, on piggui with GUI and GPIO functionality, and piglet with GPIO functionality
 .PHONY: test
 test:
-ifneq ($(PI),)
-	@echo "Detected as running on Raspberry Pi"
-	# Native compile on pi, targeting real hardware
-	cargo test --bin piggui 
-	cargo test --bin piglet 
-else
-	# Compile for host, targeting fake hardware
-	cargo test --bin piggui 
-	cargo test --bin piglet 
-endif
+	cargo test
 
 .PHONY: cross-clippy
 cross-clippy:
-	# Cross compile for pi, targeting real hardware
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --bin piggui --tests --no-deps --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --bin piglet --tests --no-deps --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --tests --no-deps --target=aarch64-unknown-linux-gnu
 
 .PHONY: cross-build
 cross-build:
-	# Cross compile for pi, targeting real hardware - debug profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --target=aarch64-unknown-linux-gnu
 
 .PHONY: cross-build-armv7
 cross-build-armv7:
-	# Cross compile for armv7 based architecture, targeting real hardware - debug profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --target=armv7-unknown-linux-gnueabihf
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --target=armv7-unknown-linux-gnueabihf
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --target=armv7-unknown-linux-gnueabihf
 
 .PHONY: cross-release-build
 cross-release-build:
-	# Cross compile for pi, targeting real hardware - release profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --release --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --release --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --release --target=aarch64-unknown-linux-gnu
 
 .PHONY: cross-release-build-armv7
 cross-release-build-armv7:
-	# Cross compile for armv7 based architecture, targeting real hardware - release profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --release --target=armv7-unknown-linux-gnueabihf
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --release --target=armv7-unknown-linux-gnueabihf
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --release --target=armv7-unknown-linux-gnueabihf
 
 .PHONY: cross-test
 cross-test:
-	# Cross compile for pi architecture, using the rppal lib that is used on real pi hw
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --bin piggui --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --bin piglet --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --target=aarch64-unknown-linux-gnu
 
 .PHONY: copy
 copy: cross-build

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ clippy:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	cargo clippy --features "pi_hw" --bin piggui --tests --no-deps
-	cargo clippy --features "pi_hw" --bin piglet --tests --no-deps
+	cargo clippy  --bin piggui --tests --no-deps
+	cargo clippy  --bin piglet --tests --no-deps
 else
 	# Compile for host, targeting fake hardware
-	cargo clippy --bin piggui --features "fake_hw" --tests --no-deps
-	cargo clippy --bin piglet --features "fake_hw" --tests --no-deps
+	cargo clippy --bin piggui  --tests --no-deps
+	cargo clippy --bin piglet  --tests --no-deps
 endif
 
 # Enable the "iced" feature so we only build the "piggui" binary on the current host (macos, linux or raspberry pi)
@@ -43,12 +43,12 @@ build:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	cargo build --bin piggui --features "pi_hw"
-	cargo build --bin piglet --features "pi_hw"
+	cargo build --bin piggui 
+	cargo build --bin piglet 
 else
 	# Compile for host, targeting fake hardware
-	cargo build --bin piggui --features "fake_hw"
-	cargo build --bin piglet --features "fake_hw"
+	cargo build --bin piggui 
+	cargo build --bin piglet 
 endif
 
 .PHONY: run
@@ -56,10 +56,10 @@ run:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	cargo run --bin piggui --features "pi_hw"
+	cargo run --bin piggui 
 else
 	# Compile for host, targeting fake hardware
-	cargo run --bin piggui --features "fake_hw"
+	cargo run --bin piggui 
 endif
 
 .PHONY: run-release
@@ -67,10 +67,10 @@ run-release:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	cargo run --bin piggui --release --features "pi_hw"
+	cargo run --bin piggui --release 
 else
 	# Compile for host, targeting fake hardware
-	cargo run --bin piggui --release --features "fake_hw"
+	cargo run --bin piggui --release 
 endif
 
 .PHONY: run-piglet
@@ -78,10 +78,10 @@ run-piglet:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	RUST_LOG=piglet=info cargo run --bin piglet --features "pi_hw"
+	RUST_LOG=piglet=info cargo run --bin piglet 
 else
 	# Compile for host, targeting fake hardware
-	RUST_LOG=piglet=info cargo run --bin piglet --features "fake_hw"
+	RUST_LOG=piglet=info cargo run --bin piglet 
 endif
 
 .PHONY: run-release-piglet
@@ -89,10 +89,10 @@ run-release-piglet:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	RUST_LOG=piglet=info cargo run --bin piglet --release --features "pi_hw"
+	RUST_LOG=piglet=info cargo run --bin piglet --release 
 else
 	# Compile for host, targeting fake hardware
-	RUST_LOG=piglet=info cargo run --bin piglet --release --features "fake_hw"
+	RUST_LOG=piglet=info cargo run --bin piglet --release 
 endif
 
 # This will build all binaries on the current host, be it macos, linux or raspberry pi - with release profile
@@ -101,12 +101,12 @@ release-build:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	cargo build --bin piggui --release --features "pi_hw"
-	cargo build --bin piglet --release --features "pi_hw"
+	cargo build --bin piggui --release 
+	cargo build --bin piglet --release 
 else
 	# Compile for host, targeting fake hardware
-	cargo build --bin piggui --release --features "fake_hw"
-	cargo build --bin piglet --release --features "fake_hw"
+	cargo build --bin piggui --release 
+	cargo build --bin piglet --release 
 endif
 
 # This will only test GUI tests in piggui on the local host, whatever that is
@@ -116,49 +116,49 @@ test:
 ifneq ($(PI),)
 	@echo "Detected as running on Raspberry Pi"
 	# Native compile on pi, targeting real hardware
-	cargo test --bin piggui --features "pi_hw"
-	cargo test --bin piglet --features "pi_hw"
+	cargo test --bin piggui 
+	cargo test --bin piglet 
 else
 	# Compile for host, targeting fake hardware
-	cargo test --bin piggui --features "fake_hw"
-	cargo test --bin piglet --features "fake_hw"
+	cargo test --bin piggui 
+	cargo test --bin piglet 
 endif
 
 .PHONY: cross-clippy
 cross-clippy:
 	# Cross compile for pi, targeting real hardware
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --bin piggui --features "pi_hw" --tests --no-deps --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --bin piglet --features "pi_hw" --tests --no-deps --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --bin piggui --tests --no-deps --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross clippy --bin piglet --tests --no-deps --target=aarch64-unknown-linux-gnu
 
 .PHONY: cross-build
 cross-build:
 	# Cross compile for pi, targeting real hardware - debug profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --features "pi_hw" --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --features "pi_hw" --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --target=aarch64-unknown-linux-gnu
 
 .PHONY: cross-build-armv7
 cross-build-armv7:
 	# Cross compile for armv7 based architecture, targeting real hardware - debug profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --features "pi_hw" --target=armv7-unknown-linux-gnueabihf
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --features "pi_hw" --target=armv7-unknown-linux-gnueabihf
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --target=armv7-unknown-linux-gnueabihf
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --target=armv7-unknown-linux-gnueabihf
 
 .PHONY: cross-release-build
 cross-release-build:
 	# Cross compile for pi, targeting real hardware - release profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --release --features "pi_hw" --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --release --features "pi_hw" --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --release --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --release --target=aarch64-unknown-linux-gnu
 
 .PHONY: cross-release-build-armv7
 cross-release-build-armv7:
 	# Cross compile for armv7 based architecture, targeting real hardware - release profile
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --release --features "pi_hw" --target=armv7-unknown-linux-gnueabihf
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --release --features "pi_hw" --target=armv7-unknown-linux-gnueabihf
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piggui --release --target=armv7-unknown-linux-gnueabihf
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross build --bin piglet --release --target=armv7-unknown-linux-gnueabihf
 
 .PHONY: cross-test
 cross-test:
 	# Cross compile for pi architecture, using the rppal lib that is used on real pi hw
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --bin piggui --features "pi_hw" --target=aarch64-unknown-linux-gnu
-	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --bin piglet --features "pi_hw" --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --bin piggui --target=aarch64-unknown-linux-gnu
+	CROSS_CONTAINER_OPTS="--platform linux/amd64" cross test --bin piglet --target=aarch64-unknown-linux-gnu
 
 .PHONY: copy
 copy: cross-build
@@ -187,8 +187,8 @@ ssh:
 .PHONY: web-build
 web-build:
 	rustup target add wasm32-unknown-unknown
-	cargo build --bin piggui --no-default-features --features "gui","fake_hw" --target wasm32-unknown-unknown
+	cargo build --bin piggui --no-default-features --target wasm32-unknown-unknown
 
 .PHONY: web-run
 web-run: web-build
-	trunk serve --features="fake_hw"
+	trunk serve

--- a/src/hw/fake_hw.rs
+++ b/src/hw/fake_hw.rs
@@ -11,22 +11,21 @@ use crate::hw::pin_description::PinDescriptionSet;
 use crate::hw::pin_descriptions::*;
 
 /// FakeHW Pins - mimicking Model the 40 pin GPIO
-// TODO make private again
 //noinspection DuplicatedCode
-pub const FAKE_PIN_DESCRIPTIONS: PinDescriptionSet = PinDescriptionSet::new([
+const FAKE_PIN_DESCRIPTIONS: PinDescriptionSet = PinDescriptionSet::new([
     PIN_1, PIN_2, PIN_3, PIN_4, PIN_5, PIN_6, PIN_7, PIN_8, PIN_9, PIN_10, PIN_11, PIN_12, PIN_13,
     PIN_14, PIN_15, PIN_16, PIN_17, PIN_18, PIN_19, PIN_20, PIN_21, PIN_22, PIN_23, PIN_24, PIN_25,
     PIN_26, PIN_27, PIN_28, PIN_29, PIN_30, PIN_31, PIN_32, PIN_33, PIN_34, PIN_35, PIN_36, PIN_37,
     PIN_38, PIN_39, PIN_40,
 ]);
 
-pub struct FakeHW;
+pub struct HW;
 
 pub fn get() -> impl Hardware {
-    FakeHW {}
+    HW {}
 }
 
-impl Hardware for FakeHW {
+impl Hardware for HW {
     fn description(&self) -> io::Result<HardwareDescription> {
         Ok(HardwareDescription {
             details: HardwareDetails {

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -14,12 +14,20 @@ pub mod config;
 /// There are two implementations of [`Hardware`] trait:
 /// * fake_hw - used on host (macOS, Linux, etc.) to show and develop GUI without real HW
 /// * pi_hw - Raspberry Pi using "rppal" crate: Should support most Pi hardware from Model B
-// TODO do this by having build script detect pi and emitting a feature
 // TODO change method to just modify path to hw module fake/pi
-#[cfg(not(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu")))]
+#[cfg(not(all(
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "arm"),
+    target_env = "gnu"
+)))]
 mod fake_hw;
-#[cfg(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "arm"),
+    target_env = "gnu"
+))]
 mod pi_hw;
+
 pub(crate) mod pin_description;
 mod pin_descriptions;
 pub mod pin_function;
@@ -36,12 +44,20 @@ pub type PinLevel = bool;
 pub const PIGLET_ALPN: &[u8] = b"pigg/piglet/0";
 
 /// Get the implementation we will use to access the underlying hardware via the [Hardware] trait
-#[cfg(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "arm"),
+    target_env = "gnu"
+))]
 pub fn get() -> impl Hardware {
     pi_hw::get()
 }
 
-#[cfg(not(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu")))]
+#[cfg(not(all(
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "arm"),
+    target_env = "gnu"
+)))]
 pub fn get() -> impl Hardware {
     fake_hw::get()
 }

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -14,9 +14,9 @@ pub mod config;
 /// There are two implementations of [`Hardware`] trait:
 /// * fake_hw - used on host (macOS, Linux, etc.) to show and develop GUI without real HW
 /// * pi_hw - Raspberry Pi using "rppal" crate: Should support most Pi hardware from Model B
-#[cfg(not(target_env = "gnu"))]
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 mod fake_hw;
-#[cfg(target_env = "gnu")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 mod pi_hw;
 pub(crate) mod pin_description;
 mod pin_descriptions;
@@ -33,12 +33,12 @@ pub type PinLevel = bool;
 pub const PIGLET_ALPN: &[u8] = b"pigg/piglet/0";
 
 /// Get the implementation we will use to access the underlying hardware via the [Hardware] trait
-#[cfg(target_env = "gnu")]
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
 pub fn get() -> impl Hardware {
     pi_hw::get()
 }
 
-#[cfg(not(target_env = "gnu"))]
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 pub fn get() -> impl Hardware {
     fake_hw::get()
 }

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -16,9 +16,9 @@ pub mod config;
 /// * pi_hw - Raspberry Pi using "rppal" crate: Should support most Pi hardware from Model B
 // TODO do this by having build script detect pi and emitting a feature
 // TODO change method to just modify path to hw module fake/pi
-#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu")))]
 mod fake_hw;
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"))]
 mod pi_hw;
 pub(crate) mod pin_description;
 mod pin_descriptions;
@@ -36,12 +36,12 @@ pub type PinLevel = bool;
 pub const PIGLET_ALPN: &[u8] = b"pigg/piglet/0";
 
 /// Get the implementation we will use to access the underlying hardware via the [Hardware] trait
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
+#[cfg(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu"))]
 pub fn get() -> impl Hardware {
     pi_hw::get()
 }
 
-#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+#[cfg(not(all(target_os = "linux", target_arch = "aarch64", target_env = "gnu")))]
 pub fn get() -> impl Hardware {
     fake_hw::get()
 }

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
-#[cfg(feature = "hardware")]
 use std::io;
 
 use crate::hw::config::HardwareConfig;
@@ -15,12 +14,11 @@ pub mod config;
 /// There are two implementations of [`Hardware`] trait:
 /// * fake_hw - used on host (macOS, Linux, etc.) to show and develop GUI without real HW
 /// * pi_hw - Raspberry Pi using "rppal" crate: Should support most Pi hardware from Model B
-#[cfg(feature = "fake_hw")]
+#[cfg(not(target_env = "gnu"))]
 mod fake_hw;
-#[cfg(feature = "pi_hw")]
+#[cfg(target_env = "gnu")]
 mod pi_hw;
 pub(crate) mod pin_description;
-#[cfg(feature = "hardware")]
 mod pin_descriptions;
 pub mod pin_function;
 
@@ -35,11 +33,12 @@ pub type PinLevel = bool;
 pub const PIGLET_ALPN: &[u8] = b"pigg/piglet/0";
 
 /// Get the implementation we will use to access the underlying hardware via the [Hardware] trait
-#[cfg(feature = "pi_hw")]
+#[cfg(target_env = "gnu")]
 pub fn get() -> impl Hardware {
     pi_hw::get()
 }
-#[cfg(feature = "fake_hw")]
+
+#[cfg(not(target_env = "gnu"))]
 pub fn get() -> impl Hardware {
     fake_hw::get()
 }
@@ -126,7 +125,6 @@ impl Display for InputPull {
 
 /// [`Hardware`] is a trait to be implemented depending on the hardware we are running on, to
 /// interact with any possible GPIO hardware on the device to set config and get state
-#[cfg(feature = "hardware")]
 pub trait Hardware {
     /// Return a [HardwareDescription] struct describing the hardware that we are connected to:
     /// * [HardwareDescription] such as revision etc.
@@ -193,7 +191,6 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "gui")]
     fn bcm_pins_sort_in_order() {
         // 0-27, not counting the gpio0 and gpio1 pins with no options
         let hw = hw::get();

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -29,6 +29,7 @@ pub type BCMPinNumber = u8;
 
 /// [BoardPinNumber] is used to refer to a GPIO pin by the numbering of the GPIO header on the Pi
 pub type BoardPinNumber = u8;
+
 /// [PinLevel] describes whether a Pin's logical level is High(true) or Low(false)
 pub type PinLevel = bool;
 

--- a/src/hw/mod.rs
+++ b/src/hw/mod.rs
@@ -14,6 +14,8 @@ pub mod config;
 /// There are two implementations of [`Hardware`] trait:
 /// * fake_hw - used on host (macOS, Linux, etc.) to show and develop GUI without real HW
 /// * pi_hw - Raspberry Pi using "rppal" crate: Should support most Pi hardware from Model B
+// TODO do this by having build script detect pi and emitting a feature
+// TODO change method to just modify path to hw module fake/pi
 #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 mod fake_hw;
 #[cfg(all(target_os = "linux", target_env = "gnu"))]

--- a/src/hw/pi_hw.rs
+++ b/src/hw/pi_hw.rs
@@ -31,18 +31,18 @@ enum Pin {
     Output(OutputPin),
 }
 
-struct PiHW {
+struct HW {
     configured_pins: HashMap<BCMPinNumber, Pin>,
 }
 
 /// This method is used to get a "handle" onto the Hardware implementation
 pub fn get() -> impl Hardware {
-    PiHW {
+    HW {
         configured_pins: Default::default(),
     }
 }
 
-impl PiHW {
+impl HW {
     fn get_details() -> io::Result<HardwareDetails> {
         let mut details = HardwareDetails {
             hardware: "Unknown".to_string(),
@@ -70,7 +70,7 @@ impl PiHW {
 
 /// Implement the [Hardware] trait for ordinary Pi hardware.
 // -> Result<(), Box<dyn Error>>
-impl Hardware for PiHW {
+impl Hardware for HW {
     /// Find the Pi hardware description
     fn description(&self) -> io::Result<HardwareDescription> {
         Ok(HardwareDescription {

--- a/src/hw/pi_hw.rs
+++ b/src/hw/pi_hw.rs
@@ -112,6 +112,7 @@ impl Hardware for PiHW {
                 self.configured_pins
                     .insert(bcm_pin_number, Pin::Input(input));
             }
+
             PinFunction::Output(value) => {
                 let pin = Gpio::new()
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?

--- a/src/hw/pin_description.rs
+++ b/src/hw/pin_description.rs
@@ -43,7 +43,6 @@ impl PinDescriptionSet {
 
     /// Return a set of PinDescriptions *only** for pins that have BCM pin numbering, sorted in
     /// ascending order of [BCMPinNumber]
-    #[cfg(any(feature = "gui", test))]
     pub fn bcm_pins_sorted(&self) -> Vec<&PinDescription> {
         let mut pins = self
             .pins

--- a/src/hw/pin_description.rs
+++ b/src/hw/pin_description.rs
@@ -43,6 +43,7 @@ impl PinDescriptionSet {
 
     /// Return a set of PinDescriptions *only** for pins that have BCM pin numbering, sorted in
     /// ascending order of [BCMPinNumber]
+    #[allow(dead_code)] // for piglet build
     pub fn bcm_pins_sorted(&self) -> Vec<&PinDescription> {
         let mut pins = self
             .pins

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -23,7 +23,6 @@ use views::pin_state::PinState;
 pub mod connect_dialog_handler;
 #[cfg(feature = "files")]
 mod file_helper;
-#[cfg(feature = "hardware")]
 pub mod hardware_subscription;
 mod hw;
 pub mod network_subscription;

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use views::pin_state::PinState;
 
 pub mod connect_dialog_handler;
-#[cfg(feature = "files")]
+#[cfg(not(target_arch = "wasm32"))]
 mod file_helper;
 pub mod hardware_subscription;
 mod hw;

--- a/src/views/hardware_menu.rs
+++ b/src/views/hardware_menu.rs
@@ -42,7 +42,6 @@ pub fn item<'a>(
             .style(MENU_BUTTON_STYLE.get_button_style()),
     );
 
-    #[cfg(feature = "hardware")]
     let connect_local: Item<'a, Message, _, _> = Item::new(
         Button::new("Use local GPIO")
             .on_press(Message::ConnectRequest(HardwareTarget::Local))
@@ -53,7 +52,6 @@ pub fn item<'a>(
     match hardware_target {
         NoHW => {
             menu_items.push(connect_remote);
-            #[cfg(feature = "hardware")]
             menu_items.push(connect_local);
         }
         HardwareTarget::Local => {
@@ -62,7 +60,6 @@ pub fn item<'a>(
         }
         Remote(_, _) => {
             menu_items.push(disconnect);
-            #[cfg(feature = "hardware")]
             menu_items.push(connect_local);
         }
     }

--- a/src/views/hardware_view.rs
+++ b/src/views/hardware_view.rs
@@ -13,7 +13,6 @@ use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::time::Duration;
 
-#[cfg(feature = "hardware")]
 use crate::hardware_subscription;
 use crate::hw::config::HardwareConfig;
 use crate::hw::pin_description::{PinDescription, PinDescriptionSet};
@@ -165,9 +164,8 @@ fn get_pin_style(pin_description: &PinDescription) -> ButtonStyle {
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub enum HardwareTarget {
-    #[cfg_attr(not(any(feature = "pi_hw", feature = "fake_hw")), default)]
     NoHW,
-    #[cfg_attr(any(feature = "pi_hw", feature = "fake_hw"), default)]
+    #[default]
     Local,
     Remote(NodeId, Option<RelayUrl>),
 }
@@ -379,7 +377,6 @@ impl HardwareView {
         match hardware_target {
             NoHW => {}
             Local => {
-                #[cfg(feature = "hardware")]
                 subscriptions.push(hardware_subscription::subscribe().map(HardwareSubscription));
             }
             Remote(nodeid, relay) => {


### PR DESCRIPTION
Try to remove the need for manually adding features by setting dependencies per target config.
Possibly add a build script to enable features depending on if on pi or not
TBD if will make fake_hw automatic when no pi_hw, or optional...
simplify Makefile
allow normal rust ways (e.g. "cargo build") to "just work"