### PR TITLE
run cross-clippy in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,10 +48,6 @@ jobs:
       - name: make
         run: make clippy build test
 
-      - name: cross clippy
-        if: runner.os == 'Linux'
-        run: make cross-clippy
-        
       - name: Add aarch64 Target with Rustup
         if: runner.os == 'Linux'
         run: rustup target add aarch64-unknown-linux-gnu
@@ -60,14 +56,10 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo install cross
 
-        # Cross build and test for aarch64-unknown-linux-gnu
-      - name: cross Build for aarch64-unknown-linux-gnu
-        if: runner.os == 'Linux'
-        run: make cross-build
 
-      - name: cross test for aarch64-unknown-linux-gnu
+      - name: cross
         if: runner.os == 'Linux'
-        run: make cross-test
+        run: make cross
 
       # lcov on ubuntu-latest (22.04) is still version 1.14 that doesn't have the "--erase-functions" option we want
       - name: clean up coverage Linux

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,6 +48,10 @@ jobs:
       - name: make
         run: make clippy build test
 
+      - name: cross clippy
+        if: runner.os == 'Linux'
+        run: make cross-clippy
+        
       - name: Add aarch64 Target with Rustup
         if: runner.os == 'Linux'
         run: rustup target add aarch64-unknown-linux-gnu

--- a/src/hw/pi_hw.rs
+++ b/src/hw/pi_hw.rs
@@ -95,7 +95,7 @@ impl Hardware for PiHW {
         match pin_function {
             PinFunction::Input(pull) => {
                 let pin = Gpio::new()
-                    .unwrap()
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
                     .get(bcm_pin_number)
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
@@ -114,7 +114,7 @@ impl Hardware for PiHW {
             }
             PinFunction::Output(value) => {
                 let pin = Gpio::new()
-                    .unwrap()
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
                     .get(bcm_pin_number)
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
                 let output_pin = match value {


### PR DESCRIPTION
It seems we weren't running corss-clippy in CI, so make cross in local fail.