### PR TITLE
Implement error feedback and display, for connection errors, timeout …

### DIFF
--- a/src/network_subscription.rs
+++ b/src/network_subscription.rs
@@ -23,11 +23,6 @@ pub enum NetworkState {
     Connected(Receiver<HardwareConfigMessage>, Connection),
 }
 
-// TODO Emit a "Connected" message when successful that will close dialog
-
-// TODO emit a "ConnectionError" Message if there were problems, this should display
-// error message
-
 /// `subscribe` implements an async sender of events from inputs, reading from the hardware and
 /// forwarding to the GUI
 pub fn subscribe(nodeid: NodeId, relay: Option<RelayUrl>) -> Subscription<HardwareEventMessage> {

--- a/src/network_subscription.rs
+++ b/src/network_subscription.rs
@@ -60,8 +60,11 @@ pub fn subscribe(nodeid: NodeId, relay: Option<RelayUrl>) -> Subscription<Hardwa
                                     NetworkState::Connected(hardware_event_receiver, connection);
                             }
                             Err(e) => {
-                                // TODO surface to the UI somehow
-                                eprintln!("Error connecting to piglet: {e}");
+                                let _ = gui_sender_clone
+                                    .send(HardwareEventMessage::Disconnected(format!(
+                                        "Error connecting to piglet: {e}"
+                                    )))
+                                    .await;
                             }
                         }
                     }

--- a/src/views/hardware_view.rs
+++ b/src/views/hardware_view.rs
@@ -72,9 +72,8 @@ const BOARD_LAYOUT_WIDTH_BETWEEN_PIN_ROWS: f32 = 10.0;
 const VERTICAL_SPACE_BETWEEN_PIN_ROWS: f32 = 5.0;
 const BCM_SPACE_BETWEEN_PIN_ROWS: f32 = 5.0;
 
-/// This enum is for events created by async events in the hardware that will be sent to the Gui
-// TODO pass PinDescriptions as a reference and handle lifetimes - clone on reception
-#[allow(clippy::large_enum_variant)] // remove when fix todo above
+/// This enum is for async events in the hardware that will be sent to the GUI
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum HardwareEventMessage {
     /// This event indicates that the listener is ready. It conveys a sender to the GUI


### PR DESCRIPTION
Fixes #283 

This PR enables erro rfeedback from the subscriber - reducing the *need* for a cancel button - removing a TODO

<img width="529" alt="Screenshot 2024-08-06 at 4 11 46 PM" src="https://github.com/user-attachments/assets/4f82ebc6-a30e-4ca4-a3cc-81c8f4728dc7">
