### PR TITLE
Remove profile

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
           components: clippy,llvm-tools-preview
 
       - name: InstallCoverageTools


### PR DESCRIPTION
GH Actions was reporting this warning:

`Warning: Unexpected input(s) 'profile', valid inputs are ['toolchain', 'targets', 'target', 'components']`

It seems that the updated rust install step doesn't accept a "profile" field.