### PR TITLE
Starting work on using discovery - but required iced updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,8 @@ path = "src/piglet.rs"
 
 [features]
 default = []
-discovery = []
 
 [dependencies]
-derive_more = "=1.0.0-beta.6" # To fix iroh-net issue
-
 # use in piggui and piglet
 chrono = { version = "0.4", default-features = false, features = ["now", "serde"] }
 serde = { version = "1.0.204", default-features = false, features = ["derive"] }
@@ -38,7 +35,7 @@ serde_json = { version = "1.0.122", default-features = false, features = ["std"]
 serde_arrays = { version = "0.1.0", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "env-filter"] }
-iroh-net = { version = "0.19.0", default-features = false }
+iroh-net = { version = "0.22.0", default-features = false, features = ["local_swarm_discovery"] }
 anyhow = { version = "1", default-features = false }
 futures-lite = { version = "2.3", default-features = false }
 tokio = { version = "1.39.2", default-features = false, features = ["time", "rt"] }
@@ -49,8 +46,8 @@ service-manager = { version = "0.7.1", default-features = false }
 sysinfo = { version = "0.31.2", default-features = false, features = ["system"] }
 
 # used by piggui in GUI only
-iced = { version = "0.12.1", default-features = false, features = ["tokio"] }
-iced_aw = { version = "0.9.3", default-features = false, features = ["menu"] }
+iced = { version = "0.13.0-dev", git = "https://github.com/iced-rs/iced.git", default-features = false, features = ["tokio"] }
+iced_aw = { version = "0.9.3", get = "https://github.com/iced-rs/iced_aw.git", default-features = false, features = ["menu"] }
 iced_futures = { version = "0.12.0", default-features = false }
 plotters-iced = { version = "0.10", default-features = false }
 plotters = { version = "0.3", default_features = false, features = [

--- a/src/views/hardware_menu.rs
+++ b/src/views/hardware_menu.rs
@@ -64,7 +64,6 @@ pub fn item<'a>(
         }
     }
 
-    #[cfg(feature = "discovery")]
     menu_items.push(Item::new(
         Button::new("Search for Pi's on local network...")
             .width(Length::Fill)


### PR DESCRIPTION
@sundaram123krishnan 

Just exploring use of discovery from iroh...

which requires updating iced ... which seems hard. Trying to use the git main while working on this leads to:

```
cargo update
    Blocking waiting for file lock on package cache
    Updating crates.io index
    Updating git repository `https://github.com/iced-rs/iced.git`
    Updating git repository `https://github.com/iced-rs/winit.git`
error: failed to select a version for `web-sys`.
    ... required by package `iced_winit v0.12.0`
    ... which satisfies dependency `iced_winit = "^0.12"` of package `iced v0.12.1`
    ... which satisfies dependency `iced = "^0.12.1"` of package `iced_aw v0.9.3`
    ... which satisfies dependency `iced_aw = "^0.9.3"` of package `pigg v0.3.4 (/Users/andrew/workspace/pigg)`
versions that meet the requirements `=0.3.67` are: 0.3.67

all possible versions conflict with previously selected packages.

  previously selected package `web-sys v0.3.69`
    ... which satisfies dependency `web-sys = "^0.3.69"` of package `iced_winit v0.13.0-dev (https://github.com/iced-rs/iced.git#d5ffe98c)`
    ... which satisfies git dependency `iced_winit` of package `iced v0.13.0-dev (https://github.com/iced-rs/iced.git#d5ffe98c)`
    ... which satisfies git dependency `iced` of package `pigg v0.3.4 (/Users/andrew/workspace/pigg)`

failed to select a version for `web-sys` which could resolve this conflict
```

So, not sure what we can do right now?