### PR TITLE
Use macos-14, macos-12, ubuntu-latest and windows-latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,9 @@ targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-dar
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[workspace.metadata.dist.github-custom-runners]
+aarch64-apple-darwin = "macos-14"
+x86_64-apple-darwin = "macos-12"
+x86_64-unknown-linux-gnu = "ubuntu-latest"
+x86_64-pc-windows-msvc = "windows-latest"


### PR DESCRIPTION
Update runner images used in release workflow 