### PR TITLE
Extend application of smaller font for picklist to all Linux

### DIFF
--- a/src/views/hardware_view.rs
+++ b/src/views/hardware_view.rs
@@ -639,11 +639,7 @@ fn create_pin_view_side<'a>(
         .placeholder("Select function");
 
         // select a slightly small font on RPi, to make it fit within pick_list
-        #[cfg(all(
-            target_os = "linux",
-            any(target_arch = "aarch64", target_arch = "arm"),
-            target_env = "gnu"
-        ))]
+        #[cfg(target_os = "linux")]
         let pick_list = pick_list.text_size(14);
         pin_options_row = pin_options_row.push(pick_list);
 


### PR DESCRIPTION
on PopOS the font needs to be smaller for picklist size also, so Im doing for all linux, not just Pi