### PR TITLE
Bump backwards once-cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ plotters = { version = "0.3", default_features = false, features = [
     "line_series",
 ] }
 tracing = { version = "0.1.40", default-features = false }
-once_cell = { version = "1.20.0", default-features = false }
+once_cell = { version = "1.19.0", default-features = false }
 lyon_algorithms = { version = "1.0", default-features = false }
 async-std = "1.13.0"
 webbrowser = { version = "1.0.2", default-features = false }


### PR DESCRIPTION
They yanked 1.20.0 so going back to an available version before releasing.