### PR TITLE
Add a "debug-probe" feature that removes some pins from Pi Pico

### DIFF
--- a/configs/pico_test.pigg
+++ b/configs/pico_test.pigg
@@ -1,1 +1,1 @@
-{"pin_functions":{"7":{"Output":true},"6":{"Input":"PullUp"},"0":{"Output":true}}}
+{"pin_functions":{"18":{"Output":true},"19":{"Input":"PullUp"}}

--- a/porky/Cargo.toml
+++ b/porky/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/porky.rs"
 
 [features]
 std = []
+debug-probe = []
 
 [dependencies]
 embassy-time = { version = "0.3.2", default-features = false, features = ["defmt", "defmt-timestamp-uptime"] }

--- a/porky/src/gpio.rs
+++ b/porky/src/gpio.rs
@@ -34,32 +34,6 @@ enum GPIOPin<'a> {
     GPIOOutput(Flex<'a>),
 }
 
-pub struct AvailablePins {
-    pub pin_3: embassy_rp::peripherals::PIN_3,
-    pub pin_4: embassy_rp::peripherals::PIN_4,
-    pub pin_5: embassy_rp::peripherals::PIN_5,
-    pub pin_6: embassy_rp::peripherals::PIN_6,
-    pub pin_7: embassy_rp::peripherals::PIN_7,
-    pub pin_8: embassy_rp::peripherals::PIN_8,
-    pub pin_9: embassy_rp::peripherals::PIN_9,
-    pub pin_10: embassy_rp::peripherals::PIN_10,
-    pub pin_11: embassy_rp::peripherals::PIN_11,
-    pub pin_12: embassy_rp::peripherals::PIN_12,
-    pub pin_13: embassy_rp::peripherals::PIN_13,
-    pub pin_14: embassy_rp::peripherals::PIN_14,
-    pub pin_15: embassy_rp::peripherals::PIN_15,
-    pub pin_16: embassy_rp::peripherals::PIN_16,
-    pub pin_17: embassy_rp::peripherals::PIN_17,
-    pub pin_18: embassy_rp::peripherals::PIN_18,
-    pub pin_19: embassy_rp::peripherals::PIN_19,
-    pub pin_20: embassy_rp::peripherals::PIN_20,
-    pub pin_21: embassy_rp::peripherals::PIN_21,
-    pub pin_22: embassy_rp::peripherals::PIN_22,
-    pub pin_26: embassy_rp::peripherals::PIN_26,
-    pub pin_27: embassy_rp::peripherals::PIN_27,
-    pub pin_28: embassy_rp::peripherals::PIN_28,
-}
-
 static mut GPIO_PINS: FnvIndexMap<BCMPinNumber, GPIOPin, 32> = FnvIndexMap::new();
 
 static RETURNER: Channel<ThreadModeRawMutex, Flex, 1> = Channel::new();
@@ -286,9 +260,57 @@ pub async fn apply_config_change<'a>(
     }
 }
 
+pub struct AvailablePins {
+    // Physical Pin # 1 - GPIO0 is connected via CYW43
+    // Physical Pin # 2 - GPIO1 is connected via CYW43
+    // Physical Pin # 3 - GROUND
+    // Physical Pin # 4 - GPIO2 is connected via CYW43
+    pub pin_3: embassy_rp::peripherals::PIN_3, // Physical Pin # 5 - GPIO3
+    pub pin_4: embassy_rp::peripherals::PIN_4, // Physical Pin # 6 - GPIO4
+    pub pin_5: embassy_rp::peripherals::PIN_5, // Physical Pin # 7 - GPIO5
+    // Physical Pin # 8 - GROUND
+    pub pin_6: embassy_rp::peripherals::PIN_6, // Physical Pin # 9 - GPIO6
+    #[cfg(not(feature = "debug-probe"))]
+    pub pin_7: embassy_rp::peripherals::PIN_7, // Physical Pin # 10 - GPIO7
+    #[cfg(not(feature = "debug-probe"))]
+    pub pin_8: embassy_rp::peripherals::PIN_8, // Physical Pin # 11 - GPIO8
+    pub pin_9: embassy_rp::peripherals::PIN_9, // Physical Pin # 12 - GPIO9
+    // Physical Pin # 13 - GROUND
+    pub pin_10: embassy_rp::peripherals::PIN_10, // Physical Pin # 14 - GPIO10
+    pub pin_11: embassy_rp::peripherals::PIN_11, // Physical Pin # 15 - GPIO11
+    pub pin_12: embassy_rp::peripherals::PIN_12, // Physical Pin # 16 - GPIO12
+    pub pin_13: embassy_rp::peripherals::PIN_13, // Physical Pin # 17 - GPIO13
+    // Physical Pin # 18 - GROUND
+    pub pin_14: embassy_rp::peripherals::PIN_14, // Physical Pin # 19 - GPIO14
+    #[cfg(not(feature = "debug-probe"))]
+    pub pin_15: embassy_rp::peripherals::PIN_15, // Physical Pin # 20 - GPIO15
+    #[cfg(not(feature = "debug-probe"))]
+    pub pin_16: embassy_rp::peripherals::PIN_16, // Physical Pin # 21 - GPIO16
+    pub pin_17: embassy_rp::peripherals::PIN_17, // Physical Pin # 22 - GPIO17
+    // Physical Pin # 23 - GROUND
+    pub pin_18: embassy_rp::peripherals::PIN_18, // Physical Pin # 24 - GPIO18
+    pub pin_19: embassy_rp::peripherals::PIN_19, // Physical Pin # 25 - GPIO19
+    pub pin_20: embassy_rp::peripherals::PIN_20, // Physical Pin # 26 - GPIO20
+    pub pin_21: embassy_rp::peripherals::PIN_21, // Physical Pin # 27 - GPIO21
+    // Physical Pin # 28 - GROUND
+    pub pin_22: embassy_rp::peripherals::PIN_22, // Physical Pin # 29 - GPIO22
+    // Physical Pin # 30 - RUN
+    pub pin_26: embassy_rp::peripherals::PIN_26, // Physical Pin # 31 - GPI=26
+    pub pin_27: embassy_rp::peripherals::PIN_27, // Physical Pin # 32 - GP1O27
+    // Physical Pin # 33 - GROUND
+    pub pin_28: embassy_rp::peripherals::PIN_28, // Physical Pin # 34 - GPIO28
+                                                 // Physical Pin # 35 - ADC_VREF
+                                                 // Physical Pin # 36 - 3V3
+                                                 // Physical Pin # 37 - 3V3_EN
+                                                 // Physical Pin # 38 - GROUND
+                                                 // Physical Pin # 39 - VSYS
+                                                 // Physical Pin # 40 - VBUS
+}
+
 /// Take the set of available pins not used by other functions, including the three pins that
 /// are connected via the CYW43 Wi-Fi chip. Create [Flex] Pins out of each of the GPIO pins.
 /// Put them all into the GPIO_PINS map, marking them as available
+/// NOTE: All pin numbers are GPIO (BCM) Pin Numbers, not physical pin numbers
 pub fn setup_pins<'a>(available_pins: AvailablePins) {
     unsafe {
         let _ = GPIO_PINS.insert(0, GPIOPin::CYW43Output); // GP0 connected to CYW43 chip
@@ -298,7 +320,9 @@ pub fn setup_pins<'a>(available_pins: AvailablePins) {
         let _ = GPIO_PINS.insert(4, GPIOPin::Available(Flex::new(available_pins.pin_4)));
         let _ = GPIO_PINS.insert(5, GPIOPin::Available(Flex::new(available_pins.pin_5)));
         let _ = GPIO_PINS.insert(6, GPIOPin::Available(Flex::new(available_pins.pin_6)));
+        #[cfg(not(feature = "debug-probe"))]
         let _ = GPIO_PINS.insert(7, GPIOPin::Available(Flex::new(available_pins.pin_7)));
+        #[cfg(not(feature = "debug-probe"))]
         let _ = GPIO_PINS.insert(8, GPIOPin::Available(Flex::new(available_pins.pin_8)));
         let _ = GPIO_PINS.insert(9, GPIOPin::Available(Flex::new(available_pins.pin_9)));
         let _ = GPIO_PINS.insert(10, GPIOPin::Available(Flex::new(available_pins.pin_10)));
@@ -306,7 +330,9 @@ pub fn setup_pins<'a>(available_pins: AvailablePins) {
         let _ = GPIO_PINS.insert(12, GPIOPin::Available(Flex::new(available_pins.pin_12)));
         let _ = GPIO_PINS.insert(13, GPIOPin::Available(Flex::new(available_pins.pin_13)));
         let _ = GPIO_PINS.insert(14, GPIOPin::Available(Flex::new(available_pins.pin_14)));
+        #[cfg(not(feature = "debug-probe"))]
         let _ = GPIO_PINS.insert(15, GPIOPin::Available(Flex::new(available_pins.pin_15)));
+        #[cfg(not(feature = "debug-probe"))]
         let _ = GPIO_PINS.insert(16, GPIOPin::Available(Flex::new(available_pins.pin_16)));
         let _ = GPIO_PINS.insert(17, GPIOPin::Available(Flex::new(available_pins.pin_17)));
         let _ = GPIO_PINS.insert(18, GPIOPin::Available(Flex::new(available_pins.pin_18)));

--- a/porky/src/gpio.rs
+++ b/porky/src/gpio.rs
@@ -261,8 +261,11 @@ pub async fn apply_config_change<'a>(
 }
 
 pub struct AvailablePins {
+    // Physical Pin # 0 - GPIO0
     // Physical Pin # 1 - GPIO0 is connected via CYW43
+    // Maybe in use by Debug-Probe
     // Physical Pin # 2 - GPIO1 is connected via CYW43
+    // Maybe in use by Debug-Probe
     // Physical Pin # 3 - GROUND
     // Physical Pin # 4 - GPIO2 is connected via CYW43
     pub pin_3: embassy_rp::peripherals::PIN_3, // Physical Pin # 5 - GPIO3
@@ -314,7 +317,9 @@ pub struct AvailablePins {
 pub fn setup_pins<'a>(available_pins: AvailablePins) {
     unsafe {
         let _ = GPIO_PINS.insert(0, GPIOPin::CYW43Output); // GP0 connected to CYW43 chip
+        #[cfg(not(feature = "debug-probe"))]
         let _ = GPIO_PINS.insert(1, GPIOPin::CYW43Output); // GP1 connected to CYW43 chip
+        #[cfg(not(feature = "debug-probe"))]
         let _ = GPIO_PINS.insert(2, GPIOPin::CYW43Input); // GP2 connected to CYW43 chip
         let _ = GPIO_PINS.insert(3, GPIOPin::Available(Flex::new(available_pins.pin_3)));
         let _ = GPIO_PINS.insert(4, GPIOPin::Available(Flex::new(available_pins.pin_4)));

--- a/porky/src/gpio.rs
+++ b/porky/src/gpio.rs
@@ -260,54 +260,85 @@ pub async fn apply_config_change<'a>(
     }
 }
 
+// GPIO Pins Used Internally that are not in the list below
+// WL_GPIO0 - via CYW43 - Connected to user LED
+// WL_GPIO1 - via CYW43 - Output controls on-board SMPS power save pin
+// WL_GPIO2 - via CYW43 - Input VBUS sense - high if VBUS is present, else wlow
+// GPIO23 - Output wireless on signal - used by embassy
+// GPIO24 - Output/Input wireless SPI data/IRQ
+// GPIO25 - Output wireless SPI CS- when high enables GPIO29 ADC pin to read VSYS
+// GPIO29 - Output/Input SPI CLK/ADC Mode to measure VSYS/3
 pub struct AvailablePins {
-    // Physical Pin # 0 - GPIO0
     // Physical Pin # 1 - GPIO0 is connected via CYW43
     // Maybe in use by Debug-Probe
     // Physical Pin # 2 - GPIO1 is connected via CYW43
     // Maybe in use by Debug-Probe
     // Physical Pin # 3 - GROUND
     // Physical Pin # 4 - GPIO2 is connected via CYW43
-    pub pin_3: embassy_rp::peripherals::PIN_3, // Physical Pin # 5 - GPIO3
-    pub pin_4: embassy_rp::peripherals::PIN_4, // Physical Pin # 6 - GPIO4
-    pub pin_5: embassy_rp::peripherals::PIN_5, // Physical Pin # 7 - GPIO5
+    // ------------------------
+    // Physical Pin # 5 - GPIO3
+    pub pin_3: embassy_rp::peripherals::PIN_3,
+    // Physical Pin # 6 - GPIO4
+    pub pin_4: embassy_rp::peripherals::PIN_4,
+    // Physical Pin # 7 - GPIO5
+    pub pin_5: embassy_rp::peripherals::PIN_5,
     // Physical Pin # 8 - GROUND
-    pub pin_6: embassy_rp::peripherals::PIN_6, // Physical Pin # 9 - GPIO6
+    // Physical Pin # 9 - GPIO6
+    pub pin_6: embassy_rp::peripherals::PIN_6,
     #[cfg(not(feature = "debug-probe"))]
-    pub pin_7: embassy_rp::peripherals::PIN_7, // Physical Pin # 10 - GPIO7
+    // Physical Pin # 10 - GPIO7
+    pub pin_7: embassy_rp::peripherals::PIN_7,
     #[cfg(not(feature = "debug-probe"))]
-    pub pin_8: embassy_rp::peripherals::PIN_8, // Physical Pin # 11 - GPIO8
-    pub pin_9: embassy_rp::peripherals::PIN_9, // Physical Pin # 12 - GPIO9
+    // Physical Pin # 11 - GPIO8
+    pub pin_8: embassy_rp::peripherals::PIN_8,
+    // Physical Pin # 12 - GPIO9
+    pub pin_9: embassy_rp::peripherals::PIN_9,
     // Physical Pin # 13 - GROUND
-    pub pin_10: embassy_rp::peripherals::PIN_10, // Physical Pin # 14 - GPIO10
-    pub pin_11: embassy_rp::peripherals::PIN_11, // Physical Pin # 15 - GPIO11
-    pub pin_12: embassy_rp::peripherals::PIN_12, // Physical Pin # 16 - GPIO12
-    pub pin_13: embassy_rp::peripherals::PIN_13, // Physical Pin # 17 - GPIO13
+    // Physical Pin # 14 - GPIO10
+    pub pin_10: embassy_rp::peripherals::PIN_10,
+    // Physical Pin # 15 - GPIO11
+    pub pin_11: embassy_rp::peripherals::PIN_11,
+    // Physical Pin # 16 - GPIO12
+    pub pin_12: embassy_rp::peripherals::PIN_12,
+    // Physical Pin # 17 - GPIO13
+    pub pin_13: embassy_rp::peripherals::PIN_13,
     // Physical Pin # 18 - GROUND
-    pub pin_14: embassy_rp::peripherals::PIN_14, // Physical Pin # 19 - GPIO14
+    // Physical Pin # 19 - GPIO14
+    pub pin_14: embassy_rp::peripherals::PIN_14,
     #[cfg(not(feature = "debug-probe"))]
-    pub pin_15: embassy_rp::peripherals::PIN_15, // Physical Pin # 20 - GPIO15
+    // Physical Pin # 20 - GPIO15
+    pub pin_15: embassy_rp::peripherals::PIN_15,
     #[cfg(not(feature = "debug-probe"))]
-    pub pin_16: embassy_rp::peripherals::PIN_16, // Physical Pin # 21 - GPIO16
-    pub pin_17: embassy_rp::peripherals::PIN_17, // Physical Pin # 22 - GPIO17
+    // Physical Pin # 21 - GPIO16
+    pub pin_16: embassy_rp::peripherals::PIN_16,
+    // Physical Pin # 22 - GPIO17
+    pub pin_17: embassy_rp::peripherals::PIN_17,
     // Physical Pin # 23 - GROUND
-    pub pin_18: embassy_rp::peripherals::PIN_18, // Physical Pin # 24 - GPIO18
-    pub pin_19: embassy_rp::peripherals::PIN_19, // Physical Pin # 25 - GPIO19
-    pub pin_20: embassy_rp::peripherals::PIN_20, // Physical Pin # 26 - GPIO20
-    pub pin_21: embassy_rp::peripherals::PIN_21, // Physical Pin # 27 - GPIO21
+    // Physical Pin # 24 - GPIO18
+    pub pin_18: embassy_rp::peripherals::PIN_18,
+    // Physical Pin # 25 - GPIO19
+    pub pin_19: embassy_rp::peripherals::PIN_19,
+    // Physical Pin # 26 - GPIO20
+    pub pin_20: embassy_rp::peripherals::PIN_20,
+    // Physical Pin # 27 - GPIO21
+    pub pin_21: embassy_rp::peripherals::PIN_21,
     // Physical Pin # 28 - GROUND
-    pub pin_22: embassy_rp::peripherals::PIN_22, // Physical Pin # 29 - GPIO22
+    // Physical Pin # 29 - GPIO22
+    pub pin_22: embassy_rp::peripherals::PIN_22,
     // Physical Pin # 30 - RUN
-    pub pin_26: embassy_rp::peripherals::PIN_26, // Physical Pin # 31 - GPI=26
-    pub pin_27: embassy_rp::peripherals::PIN_27, // Physical Pin # 32 - GP1O27
+    // Physical Pin # 31 - GPIO26
+    pub pin_26: embassy_rp::peripherals::PIN_26,
+    // Physical Pin # 32 - GP1O27
+    pub pin_27: embassy_rp::peripherals::PIN_27,
     // Physical Pin # 33 - GROUND
-    pub pin_28: embassy_rp::peripherals::PIN_28, // Physical Pin # 34 - GPIO28
-                                                 // Physical Pin # 35 - ADC_VREF
-                                                 // Physical Pin # 36 - 3V3
-                                                 // Physical Pin # 37 - 3V3_EN
-                                                 // Physical Pin # 38 - GROUND
-                                                 // Physical Pin # 39 - VSYS
-                                                 // Physical Pin # 40 - VBUS
+    // Physical Pin # 34 - GPIO28
+    pub pin_28: embassy_rp::peripherals::PIN_28,
+    // Physical Pin # 35 - ADC_VREF
+    // Physical Pin # 36 - 3V3
+    // Physical Pin # 37 - 3V3_EN
+    // Physical Pin # 38 - GROUND
+    // Physical Pin # 39 - VSYS
+    // Physical Pin # 40 - VBUS
 }
 
 /// Take the set of available pins not used by other functions, including the three pins that

--- a/porky/src/gpio.rs
+++ b/porky/src/gpio.rs
@@ -260,78 +260,86 @@ pub async fn apply_config_change<'a>(
     }
 }
 
+// Pins available to be programmed, but are not connected to header
+//  WL_GPIO0 - via CYW43 - Connected to user LED
+//  WL_GPIO1 - via CYW43 - Output controls on-board SMPS power save pin
+//  WL_GPIO2 - via CYW43 - Input VBUS sense - high if VBUS is present, else low
+//
 // GPIO Pins Used Internally that are not in the list below
-// WL_GPIO0 - via CYW43 - Connected to user LED
-// WL_GPIO1 - via CYW43 - Output controls on-board SMPS power save pin
-// WL_GPIO2 - via CYW43 - Input VBUS sense - high if VBUS is present, else wlow
-// GPIO23 - Output wireless on signal - used by embassy
-// GPIO24 - Output/Input wireless SPI data/IRQ
-// GPIO25 - Output wireless SPI CS- when high enables GPIO29 ADC pin to read VSYS
-// GPIO29 - Output/Input SPI CLK/ADC Mode to measure VSYS/3
-pub struct AvailablePins {
-    // Physical Pin # 1 - GPIO0 is connected via CYW43
+//  GP23 - Output wireless on signal - used by embassy
+//  GP24 - Output/Input wireless SPI data/IRQ
+//  GP25 - Output wireless SPI CS- when high enables GPIO29 ADC pin to read VSYS
+//  GP29 - Output/Input SPI CLK/ADC Mode to measure VSYS/3
+//
+// Refer to $ProjectRoot/assets/images/pi_pico_w_pinout.png
+pub struct HeaderPins {
+    // Physical Pin # 1 - GP0
     // Maybe in use by Debug-Probe
-    // Physical Pin # 2 - GPIO1 is connected via CYW43
+    #[cfg(not(feature = "debug-probe"))]
+    pub pin_0: embassy_rp::peripherals::PIN_0,
+    // Physical Pin # 2 - GP1
     // Maybe in use by Debug-Probe
+    #[cfg(not(feature = "debug-probe"))]
+    pub pin_1: embassy_rp::peripherals::PIN_1,
     // Physical Pin # 3 - GROUND
-    // Physical Pin # 4 - GPIO2 is connected via CYW43
-    // ------------------------
-    // Physical Pin # 5 - GPIO3
+    // Physical Pin # 4 - GP2
+    pub pin_2: embassy_rp::peripherals::PIN_2,
+    // Physical Pin # 5 - GP3
     pub pin_3: embassy_rp::peripherals::PIN_3,
-    // Physical Pin # 6 - GPIO4
+    // Physical Pin # 6 - GP4
     pub pin_4: embassy_rp::peripherals::PIN_4,
-    // Physical Pin # 7 - GPIO5
+    // Physical Pin # 7 - GP5
     pub pin_5: embassy_rp::peripherals::PIN_5,
     // Physical Pin # 8 - GROUND
-    // Physical Pin # 9 - GPIO6
+    // Physical Pin # 9 - GP6
     pub pin_6: embassy_rp::peripherals::PIN_6,
     #[cfg(not(feature = "debug-probe"))]
-    // Physical Pin # 10 - GPIO7
+    // Physical Pin # 10 - GP7
     pub pin_7: embassy_rp::peripherals::PIN_7,
     #[cfg(not(feature = "debug-probe"))]
-    // Physical Pin # 11 - GPIO8
+    // Physical Pin # 11 - GP8
     pub pin_8: embassy_rp::peripherals::PIN_8,
-    // Physical Pin # 12 - GPIO9
+    // Physical Pin # 12 - GP9
     pub pin_9: embassy_rp::peripherals::PIN_9,
     // Physical Pin # 13 - GROUND
-    // Physical Pin # 14 - GPIO10
+    // Physical Pin # 14 - GP10
     pub pin_10: embassy_rp::peripherals::PIN_10,
-    // Physical Pin # 15 - GPIO11
+    // Physical Pin # 15 - GP11
     pub pin_11: embassy_rp::peripherals::PIN_11,
-    // Physical Pin # 16 - GPIO12
+    // Physical Pin # 16 - GP12
     pub pin_12: embassy_rp::peripherals::PIN_12,
-    // Physical Pin # 17 - GPIO13
+    // Physical Pin # 17 - GP13
     pub pin_13: embassy_rp::peripherals::PIN_13,
     // Physical Pin # 18 - GROUND
-    // Physical Pin # 19 - GPIO14
+    // Physical Pin # 19 - GP14
     pub pin_14: embassy_rp::peripherals::PIN_14,
     #[cfg(not(feature = "debug-probe"))]
-    // Physical Pin # 20 - GPIO15
+    // Physical Pin # 20 - GP15
     pub pin_15: embassy_rp::peripherals::PIN_15,
     #[cfg(not(feature = "debug-probe"))]
-    // Physical Pin # 21 - GPIO16
+    // Physical Pin # 21 - GP16
     pub pin_16: embassy_rp::peripherals::PIN_16,
-    // Physical Pin # 22 - GPIO17
+    // Physical Pin # 22 - GP17
     pub pin_17: embassy_rp::peripherals::PIN_17,
     // Physical Pin # 23 - GROUND
-    // Physical Pin # 24 - GPIO18
+    // Physical Pin # 24 - GP18
     pub pin_18: embassy_rp::peripherals::PIN_18,
-    // Physical Pin # 25 - GPIO19
+    // Physical Pin # 25 - GP19
     pub pin_19: embassy_rp::peripherals::PIN_19,
-    // Physical Pin # 26 - GPIO20
+    // Physical Pin # 26 - GP20
     pub pin_20: embassy_rp::peripherals::PIN_20,
-    // Physical Pin # 27 - GPIO21
+    // Physical Pin # 27 - GP21
     pub pin_21: embassy_rp::peripherals::PIN_21,
     // Physical Pin # 28 - GROUND
-    // Physical Pin # 29 - GPIO22
+    // Physical Pin # 29 - GP22
     pub pin_22: embassy_rp::peripherals::PIN_22,
     // Physical Pin # 30 - RUN
-    // Physical Pin # 31 - GPIO26
+    // Physical Pin # 31 - GP26
     pub pin_26: embassy_rp::peripherals::PIN_26,
-    // Physical Pin # 32 - GP1O27
+    // Physical Pin # 32 - GP27
     pub pin_27: embassy_rp::peripherals::PIN_27,
     // Physical Pin # 33 - GROUND
-    // Physical Pin # 34 - GPIO28
+    // Physical Pin # 34 - GP28
     pub pin_28: embassy_rp::peripherals::PIN_28,
     // Physical Pin # 35 - ADC_VREF
     // Physical Pin # 36 - 3V3
@@ -345,40 +353,46 @@ pub struct AvailablePins {
 /// are connected via the CYW43 Wi-Fi chip. Create [Flex] Pins out of each of the GPIO pins.
 /// Put them all into the GPIO_PINS map, marking them as available
 /// NOTE: All pin numbers are GPIO (BCM) Pin Numbers, not physical pin numbers
-pub fn setup_pins<'a>(available_pins: AvailablePins) {
+/// TODO we need to find a way to control these other pins
+///         let _ = GPIO_PINS.insert(0, GPIOPin::CYW43Output); // GP0 connected to CYW43 chip
+//         #[cfg(not(feature = "debug-probe"))]
+//         let _ = GPIO_PINS.insert(1, GPIOPin::CYW43Output); // GP1 connected to CYW43 chip
+//         #[cfg(not(feature = "debug-probe"))]
+//         let _ = GPIO_PINS.insert(2, GPIOPin::CYW43Input); // GP2 connected to CYW43 chip
+pub fn setup_pins<'a>(header_pins: HeaderPins) {
     unsafe {
-        let _ = GPIO_PINS.insert(0, GPIOPin::CYW43Output); // GP0 connected to CYW43 chip
         #[cfg(not(feature = "debug-probe"))]
-        let _ = GPIO_PINS.insert(1, GPIOPin::CYW43Output); // GP1 connected to CYW43 chip
+        let _ = GPIO_PINS.insert(0, GPIOPin::Available(Flex::new(header_pins.pin_0)));
         #[cfg(not(feature = "debug-probe"))]
-        let _ = GPIO_PINS.insert(2, GPIOPin::CYW43Input); // GP2 connected to CYW43 chip
-        let _ = GPIO_PINS.insert(3, GPIOPin::Available(Flex::new(available_pins.pin_3)));
-        let _ = GPIO_PINS.insert(4, GPIOPin::Available(Flex::new(available_pins.pin_4)));
-        let _ = GPIO_PINS.insert(5, GPIOPin::Available(Flex::new(available_pins.pin_5)));
-        let _ = GPIO_PINS.insert(6, GPIOPin::Available(Flex::new(available_pins.pin_6)));
+        let _ = GPIO_PINS.insert(1, GPIOPin::Available(Flex::new(header_pins.pin_1)));
+        let _ = GPIO_PINS.insert(2, GPIOPin::Available(Flex::new(header_pins.pin_2)));
+        let _ = GPIO_PINS.insert(3, GPIOPin::Available(Flex::new(header_pins.pin_3)));
+        let _ = GPIO_PINS.insert(4, GPIOPin::Available(Flex::new(header_pins.pin_4)));
+        let _ = GPIO_PINS.insert(5, GPIOPin::Available(Flex::new(header_pins.pin_5)));
+        let _ = GPIO_PINS.insert(6, GPIOPin::Available(Flex::new(header_pins.pin_6)));
         #[cfg(not(feature = "debug-probe"))]
-        let _ = GPIO_PINS.insert(7, GPIOPin::Available(Flex::new(available_pins.pin_7)));
+        let _ = GPIO_PINS.insert(7, GPIOPin::Available(Flex::new(header_pins.pin_7)));
         #[cfg(not(feature = "debug-probe"))]
-        let _ = GPIO_PINS.insert(8, GPIOPin::Available(Flex::new(available_pins.pin_8)));
-        let _ = GPIO_PINS.insert(9, GPIOPin::Available(Flex::new(available_pins.pin_9)));
-        let _ = GPIO_PINS.insert(10, GPIOPin::Available(Flex::new(available_pins.pin_10)));
-        let _ = GPIO_PINS.insert(11, GPIOPin::Available(Flex::new(available_pins.pin_11)));
-        let _ = GPIO_PINS.insert(12, GPIOPin::Available(Flex::new(available_pins.pin_12)));
-        let _ = GPIO_PINS.insert(13, GPIOPin::Available(Flex::new(available_pins.pin_13)));
-        let _ = GPIO_PINS.insert(14, GPIOPin::Available(Flex::new(available_pins.pin_14)));
+        let _ = GPIO_PINS.insert(8, GPIOPin::Available(Flex::new(header_pins.pin_8)));
+        let _ = GPIO_PINS.insert(9, GPIOPin::Available(Flex::new(header_pins.pin_9)));
+        let _ = GPIO_PINS.insert(10, GPIOPin::Available(Flex::new(header_pins.pin_10)));
+        let _ = GPIO_PINS.insert(11, GPIOPin::Available(Flex::new(header_pins.pin_11)));
+        let _ = GPIO_PINS.insert(12, GPIOPin::Available(Flex::new(header_pins.pin_12)));
+        let _ = GPIO_PINS.insert(13, GPIOPin::Available(Flex::new(header_pins.pin_13)));
+        let _ = GPIO_PINS.insert(14, GPIOPin::Available(Flex::new(header_pins.pin_14)));
         #[cfg(not(feature = "debug-probe"))]
-        let _ = GPIO_PINS.insert(15, GPIOPin::Available(Flex::new(available_pins.pin_15)));
+        let _ = GPIO_PINS.insert(15, GPIOPin::Available(Flex::new(header_pins.pin_15)));
         #[cfg(not(feature = "debug-probe"))]
-        let _ = GPIO_PINS.insert(16, GPIOPin::Available(Flex::new(available_pins.pin_16)));
-        let _ = GPIO_PINS.insert(17, GPIOPin::Available(Flex::new(available_pins.pin_17)));
-        let _ = GPIO_PINS.insert(18, GPIOPin::Available(Flex::new(available_pins.pin_18)));
-        let _ = GPIO_PINS.insert(19, GPIOPin::Available(Flex::new(available_pins.pin_19)));
-        let _ = GPIO_PINS.insert(20, GPIOPin::Available(Flex::new(available_pins.pin_20)));
-        let _ = GPIO_PINS.insert(21, GPIOPin::Available(Flex::new(available_pins.pin_21)));
-        let _ = GPIO_PINS.insert(22, GPIOPin::Available(Flex::new(available_pins.pin_22)));
-        let _ = GPIO_PINS.insert(26, GPIOPin::Available(Flex::new(available_pins.pin_26)));
-        let _ = GPIO_PINS.insert(27, GPIOPin::Available(Flex::new(available_pins.pin_27)));
-        let _ = GPIO_PINS.insert(28, GPIOPin::Available(Flex::new(available_pins.pin_28)));
+        let _ = GPIO_PINS.insert(16, GPIOPin::Available(Flex::new(header_pins.pin_16)));
+        let _ = GPIO_PINS.insert(17, GPIOPin::Available(Flex::new(header_pins.pin_17)));
+        let _ = GPIO_PINS.insert(18, GPIOPin::Available(Flex::new(header_pins.pin_18)));
+        let _ = GPIO_PINS.insert(19, GPIOPin::Available(Flex::new(header_pins.pin_19)));
+        let _ = GPIO_PINS.insert(20, GPIOPin::Available(Flex::new(header_pins.pin_20)));
+        let _ = GPIO_PINS.insert(21, GPIOPin::Available(Flex::new(header_pins.pin_21)));
+        let _ = GPIO_PINS.insert(22, GPIOPin::Available(Flex::new(header_pins.pin_22)));
+        let _ = GPIO_PINS.insert(26, GPIOPin::Available(Flex::new(header_pins.pin_26)));
+        let _ = GPIO_PINS.insert(27, GPIOPin::Available(Flex::new(header_pins.pin_27)));
+        let _ = GPIO_PINS.insert(28, GPIOPin::Available(Flex::new(header_pins.pin_28)));
     }
     info!("GPIO Pins setup");
 }

--- a/porky/src/pin_descriptions.rs
+++ b/porky/src/pin_descriptions.rs
@@ -101,6 +101,15 @@ const PIN_9: PinDescription = PinDescription {
     ],
 };
 
+#[cfg(feature = "debug-probe")]
+const PIN_10: PinDescription = PinDescription {
+    bpn: 10,
+    bcm: Some(7),
+    name: "Debug-Probe",
+    options: &[],
+};
+
+#[cfg(not(feature = "debug-probe"))]
 const PIN_10: PinDescription = PinDescription {
     bpn: 10,
     bcm: Some(7),
@@ -113,6 +122,15 @@ const PIN_10: PinDescription = PinDescription {
     ],
 };
 
+#[cfg(feature = "debug-probe")]
+const PIN_11: PinDescription = PinDescription {
+    bpn: 11,
+    bcm: Some(8),
+    name: "Debug-Probe",
+    options: &[],
+};
+
+#[cfg(not(feature = "debug-probe"))]
 const PIN_11: PinDescription = PinDescription {
     bpn: 11,
     bcm: Some(8),
@@ -215,6 +233,15 @@ const PIN_19: PinDescription = PinDescription {
     ],
 };
 
+#[cfg(feature = "debug-probe")]
+const PIN_20: PinDescription = PinDescription {
+    bpn: 20,
+    bcm: Some(15),
+    name: "Debug-Probe",
+    options: &[],
+};
+
+#[cfg(not(feature = "debug-probe"))]
 const PIN_20: PinDescription = PinDescription {
     bpn: 20,
     bcm: Some(15),
@@ -227,6 +254,15 @@ const PIN_20: PinDescription = PinDescription {
     ],
 };
 
+#[cfg(feature = "debug-probe")]
+const PIN_21: PinDescription = PinDescription {
+    bpn: 21,
+    bcm: Some(16),
+    name: "Debug-Probe",
+    options: &[],
+};
+
+#[cfg(not(feature = "debug-probe"))]
 const PIN_21: PinDescription = PinDescription {
     bpn: 21,
     bcm: Some(16),

--- a/porky/src/pin_descriptions.rs
+++ b/porky/src/pin_descriptions.rs
@@ -2,6 +2,15 @@ use crate::hw_definition::config::InputPull;
 use crate::hw_definition::description::PinDescription;
 use crate::hw_definition::pin_function::PinFunction;
 
+#[cfg(feature = "debug-probe")]
+const PIN_1: PinDescription = PinDescription {
+    bpn: 1,
+    bcm: Some(0),
+    name: "Debug-Probe",
+    options: &[],
+};
+
+#[cfg(not(feature = "debug-probe"))]
 const PIN_1: PinDescription = PinDescription {
     bpn: 1,
     bcm: Some(0),
@@ -14,6 +23,15 @@ const PIN_1: PinDescription = PinDescription {
     ],
 };
 
+#[cfg(feature = "debug-probe")]
+const PIN_2: PinDescription = PinDescription {
+    bpn: 2,
+    bcm: Some(1),
+    name: "Debug-Probe",
+    options: &[],
+};
+
+#[cfg(not(feature = "debug-probe"))]
 const PIN_2: PinDescription = PinDescription {
     bpn: 2,
     bcm: Some(1),

--- a/porky/src/porky.rs
+++ b/porky/src/porky.rs
@@ -70,7 +70,9 @@ async fn main(spawner: Spawner) {
         pin_4: peripherals.PIN_4,
         pin_5: peripherals.PIN_5,
         pin_6: peripherals.PIN_6,
+        #[cfg(not(feature = "debug-probe"))]
         pin_7: peripherals.PIN_7,
+        #[cfg(not(feature = "debug-probe"))]
         pin_8: peripherals.PIN_8,
         pin_9: peripherals.PIN_9,
         pin_10: peripherals.PIN_10,
@@ -78,7 +80,9 @@ async fn main(spawner: Spawner) {
         pin_12: peripherals.PIN_12,
         pin_13: peripherals.PIN_13,
         pin_14: peripherals.PIN_14,
+        #[cfg(not(feature = "debug-probe"))]
         pin_15: peripherals.PIN_15,
+        #[cfg(not(feature = "debug-probe"))]
         pin_16: peripherals.PIN_16,
         pin_17: peripherals.PIN_17,
         pin_18: peripherals.PIN_18,

--- a/src/views/hardware_view.rs
+++ b/src/views/hardware_view.rs
@@ -649,16 +649,18 @@ fn create_pin_view_side<'a>(
         // Filter options
         let config_options = filter_options(&pin_description.options, pin_function.cloned());
 
-        let selected = pin_function.filter(|&pin_function| *pin_function != PinFunction::None);
+        if !config_options.is_empty() {
+            let selected = pin_function.filter(|&pin_function| *pin_function != PinFunction::None);
 
-        let pick_list = pick_list(config_options, selected, move |pin_function| {
-            PinFunctionSelected(bcm_pin_number, pin_function)
-        })
-        .width(Length::Fixed(PIN_OPTION_WIDTH))
-        .placeholder("Select function");
+            let pick_list = pick_list(config_options, selected, move |pin_function| {
+                PinFunctionSelected(bcm_pin_number, pin_function)
+            })
+            .width(Length::Fixed(PIN_OPTION_WIDTH))
+            .placeholder("Select function");
 
-        // select a slightly small font on RPi, to make it fit within pick_list
-        pin_options_row = pin_options_row.push(pick_list);
+            // select a slightly small font on RPi, to make it fit within pick_list
+            pin_options_row = pin_options_row.push(pick_list);
+        }
 
         pin_option = pin_option.push(pin_options_row);
     }


### PR DESCRIPTION
Some pins are not usable when a debug probe is being used.
Add a feature that can be used to remove them from the UI and avoid configuring them.
Adapt the UI to not show a pick list when there are no options to chose from.