### PR TITLE
The GPIO lines listed on the diagram are indeed the lines that the re…

### DIFF
--- a/porky/src/gpio.rs
+++ b/porky/src/gpio.rs
@@ -293,10 +293,8 @@ pub struct HeaderPins {
     // Physical Pin # 8 - GROUND
     // Physical Pin # 9 - GP6
     pub pin_6: embassy_rp::peripherals::PIN_6,
-    #[cfg(not(feature = "debug-probe"))]
     // Physical Pin # 10 - GP7
     pub pin_7: embassy_rp::peripherals::PIN_7,
-    #[cfg(not(feature = "debug-probe"))]
     // Physical Pin # 11 - GP8
     pub pin_8: embassy_rp::peripherals::PIN_8,
     // Physical Pin # 12 - GP9
@@ -313,10 +311,8 @@ pub struct HeaderPins {
     // Physical Pin # 18 - GROUND
     // Physical Pin # 19 - GP14
     pub pin_14: embassy_rp::peripherals::PIN_14,
-    #[cfg(not(feature = "debug-probe"))]
     // Physical Pin # 20 - GP15
     pub pin_15: embassy_rp::peripherals::PIN_15,
-    #[cfg(not(feature = "debug-probe"))]
     // Physical Pin # 21 - GP16
     pub pin_16: embassy_rp::peripherals::PIN_16,
     // Physical Pin # 22 - GP17

--- a/porky/src/pin_descriptions.rs
+++ b/porky/src/pin_descriptions.rs
@@ -119,15 +119,6 @@ const PIN_9: PinDescription = PinDescription {
     ],
 };
 
-#[cfg(feature = "debug-probe")]
-const PIN_10: PinDescription = PinDescription {
-    bpn: 10,
-    bcm: Some(7),
-    name: "Debug-Probe",
-    options: &[],
-};
-
-#[cfg(not(feature = "debug-probe"))]
 const PIN_10: PinDescription = PinDescription {
     bpn: 10,
     bcm: Some(7),
@@ -140,15 +131,6 @@ const PIN_10: PinDescription = PinDescription {
     ],
 };
 
-#[cfg(feature = "debug-probe")]
-const PIN_11: PinDescription = PinDescription {
-    bpn: 11,
-    bcm: Some(8),
-    name: "Debug-Probe",
-    options: &[],
-};
-
-#[cfg(not(feature = "debug-probe"))]
 const PIN_11: PinDescription = PinDescription {
     bpn: 11,
     bcm: Some(8),
@@ -251,15 +233,6 @@ const PIN_19: PinDescription = PinDescription {
     ],
 };
 
-#[cfg(feature = "debug-probe")]
-const PIN_20: PinDescription = PinDescription {
-    bpn: 20,
-    bcm: Some(15),
-    name: "Debug-Probe",
-    options: &[],
-};
-
-#[cfg(not(feature = "debug-probe"))]
 const PIN_20: PinDescription = PinDescription {
     bpn: 20,
     bcm: Some(15),
@@ -272,15 +245,6 @@ const PIN_20: PinDescription = PinDescription {
     ],
 };
 
-#[cfg(feature = "debug-probe")]
-const PIN_21: PinDescription = PinDescription {
-    bpn: 21,
-    bcm: Some(16),
-    name: "Debug-Probe",
-    options: &[],
-};
-
-#[cfg(not(feature = "debug-probe"))]
 const PIN_21: PinDescription = PinDescription {
     bpn: 21,
     bcm: Some(16),

--- a/porky/src/porky.rs
+++ b/porky/src/porky.rs
@@ -82,9 +82,7 @@ async fn main(spawner: Spawner) {
         pin_4: peripherals.PIN_4,
         pin_5: peripherals.PIN_5,
         pin_6: peripherals.PIN_6,
-        #[cfg(not(feature = "debug-probe"))]
         pin_7: peripherals.PIN_7,
-        #[cfg(not(feature = "debug-probe"))]
         pin_8: peripherals.PIN_8,
         pin_9: peripherals.PIN_9,
         pin_10: peripherals.PIN_10,
@@ -92,9 +90,7 @@ async fn main(spawner: Spawner) {
         pin_12: peripherals.PIN_12,
         pin_13: peripherals.PIN_13,
         pin_14: peripherals.PIN_14,
-        #[cfg(not(feature = "debug-probe"))]
         pin_15: peripherals.PIN_15,
-        #[cfg(not(feature = "debug-probe"))]
         pin_16: peripherals.PIN_16,
         pin_17: peripherals.PIN_17,
         pin_18: peripherals.PIN_18,


### PR DESCRIPTION
The GPIO lines listed on the debug probe diagram are indeed the lines that the respective LED's are connected to (via 470R resistors). On the debug probe they do not connect to the Pico under debug.

So those numbered pins on the Pico are free to be used as general GPIO.