### PR TITLE
Implement dialog to configure wifi of USB connected porky

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -149,7 +149,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           grcov . --binary-path target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" -o lcov.info
-          lcov --ignore-errors empty,empty --remove lcov.info -o lcov.info --erase-functions "(?=^.*fmt).+"
+          lcov --ignore-errors unsupported --ignore-errors empty,empty --remove lcov.info -o lcov.info --erase-functions "(?=^.*fmt).+"
 
       - name: UploadCoverage
         if: runner.os != 'Windows'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ x86_64-pc-windows-msvc = "windows-latest"
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
-always_include_features = ["std"]
+denylist = ["no_std"]
 
 [package.metadata.docs.rs]
 features = ["iroh", "tcp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ name = "piglet"
 path = "src/piglet.rs"
 
 [features]
-default = ["iroh", "tcp", "std", "usb-raw", "discovery"]
+default = ["iroh", "tcp", "usb-raw", "discovery"]
 iroh = ["iroh-net"]
 tcp = ["portpicker", "local-ip-address"]
 discovery = []
-std = []
+no_std = []
 usb-raw = ["nusb"]
 
 [dependencies]

--- a/porky/Cargo.lock
+++ b/porky/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "cyw43"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "bt-hci",
  "cortex-m",
@@ -213,7 +213,7 @@ dependencies = [
 [[package]]
 name = "cyw43-pio"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "cyw43",
  "defmt",
@@ -349,9 +349,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "ekv"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab888debca410aa6f2726fb363926ca73539378c5e8880c8f08f35ae4b24d938"
+dependencies = [
+ "embassy-sync 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapless 0.8.0",
+]
+
+[[package]]
 name = "embassy-embedded-hal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "embassy-futures 0.1.1 (git+https://github.com/embassy-rs/embassy.git)",
  "embassy-sync 0.6.0 (git+https://github.com/embassy-rs/embassy.git)",
@@ -366,8 +376,8 @@ dependencies = [
 
 [[package]]
 name = "embassy-executor"
-version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+version = "0.6.3"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -376,13 +386,12 @@ dependencies = [
  "embassy-executor-macros",
  "embassy-time-driver",
  "embassy-time-queue-driver",
- "rustc_version 0.4.1",
 ]
 
 [[package]]
 name = "embassy-executor-macros"
 version = "0.6.2"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -399,12 +408,12 @@ checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -415,7 +424,7 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.4.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "defmt",
  "document-features",
@@ -432,7 +441,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "defmt",
 ]
@@ -440,7 +449,7 @@ dependencies = [
 [[package]]
 name = "embassy-net-driver-channel"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "embassy-futures 0.1.1 (git+https://github.com/embassy-rs/embassy.git)",
  "embassy-net-driver",
@@ -450,7 +459,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.2.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
@@ -501,7 +510,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.6.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -514,7 +523,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.3.2"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -532,7 +541,7 @@ dependencies = [
 [[package]]
 name = "embassy-time-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "document-features",
 ]
@@ -540,12 +549,12 @@ dependencies = [
 [[package]]
 name = "embassy-time-queue-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 
 [[package]]
 name = "embassy-usb"
 version = "0.3.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "embassy-futures 0.1.1 (git+https://github.com/embassy-rs/embassy.git)",
  "embassy-net-driver-channel",
@@ -557,7 +566,7 @@ dependencies = [
 [[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git#e1501a21a878a96ea5cc01f2ce5574a115a53193"
+source = "git+https://github.com/embassy-rs/embassy.git#015e3aecb410c2d5afefb908b4d4171d5b478be3"
 dependencies = [
  "defmt",
 ]
@@ -927,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libredox"
@@ -1150,6 +1159,7 @@ dependencies = [
  "cyw43-pio",
  "defmt",
  "defmt-rtt",
+ "ekv",
  "embassy-executor",
  "embassy-futures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "embassy-net",
@@ -1158,6 +1168,7 @@ dependencies = [
  "embassy-time",
  "embassy-usb",
  "embedded-io-async",
+ "embedded-storage",
  "faster-hex",
  "heapless 0.8.0",
  "panic-probe",
@@ -1287,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1388,18 +1399,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1551,18 +1562,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/porky/Cargo.toml
+++ b/porky/Cargo.toml
@@ -9,8 +9,8 @@ name = "porky"
 path = "src/porky.rs"
 
 [features]
-default = ["usb-raw"]
-std = []
+default = ["usb-raw", "no_std"]
+no_std = []
 debug-probe = []
 usb-tcp = ["usb"]
 usb-raw = ["usb"]

--- a/porky/Cargo.toml
+++ b/porky/Cargo.toml
@@ -69,7 +69,8 @@ cyw43-pio = { git = "https://github.com/embassy-rs/embassy.git" }
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true
-denylist = ["std", "usb"]
+denylist = ["usb"]
+always_include_features = ["no_std"]
 # Features "usb-raw" and "usb-tcp" are incompatible, so skip permutations including them
 skip_feature_sets = [
     ["usb-raw", "usb-tcp"],

--- a/porky/Cargo.toml
+++ b/porky/Cargo.toml
@@ -41,6 +41,9 @@ serde = { version = "1.0.208", default-features = false, features = ["derive"] }
 postcard = { version = "1.0.10", default-features = false, features = ["heapless"] }
 heapless = { version = "0.8.0", default-features = false, features = ["serde"] }
 
+ekv = { version = "1.0.0", default-features = false }
+embedded-storage = { version = "0.3", default-features = false }
+
 [build-dependencies]
 # for reading SSID config from a file in build.rs
 serde_derive = "~1.0"

--- a/porky/Cargo.toml
+++ b/porky/Cargo.toml
@@ -21,7 +21,6 @@ embassy-time = { version = "0.3.2", default-features = false, features = ["defmt
 embassy-executor = { version = "0.6.0", default-features = false, features = ["task-arena-size-65536", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
 embassy-rp = { version = "0.2.0", default-features = false, features = ["rp2040", "defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
 embassy-net = { version = "0.4.0", default-features = false, features = ["defmt", "tcp", "udp", "dns", "dhcpv4"] }
-embassy-usb = { version = "0.3.0", default-features = false, optional = true }
 cyw43 = { version = "0.2.0", default-features = false, features = ["defmt"] }
 cyw43-pio = { version = "0.2.0", default-features = false, features = ["defmt"] }
 panic-probe = { version = "0.3", default-features = false, features = ["print-defmt"] }
@@ -43,6 +42,9 @@ heapless = { version = "0.8.0", default-features = false, features = ["serde"] }
 
 ekv = { version = "1.0.0", default-features = false }
 embedded-storage = { version = "0.3", default-features = false }
+
+# Optional Dependencies
+embassy-usb = { version = "0.3.0", default-features = false, optional = true }
 
 [build-dependencies]
 # for reading SSID config from a file in build.rs

--- a/porky/build.rs
+++ b/porky/build.rs
@@ -42,25 +42,23 @@ fn generate_ssid(filename: &str, ssid: SsidSpec) -> io::Result<()> {
     let mut file = File::create(out_file).unwrap();
 
     file.write_all(
-        format!(
-            "pub(crate) const SSID_NAME : &str = \"{}\";\n",
-            ssid.ssid_name
-        )
-        .as_bytes(),
+        b"\
+use heapless::String;\n
+use crate::hw_definition::description::SsidSpec;\n\
+use core::str::FromStr;\n",
     )?;
 
     file.write_all(
         format!(
-            "pub(crate) const SSID_PASS : &str = \"{}\";\n",
-            ssid.ssid_pass
-        )
-        .as_bytes(),
-    )?;
-
-    file.write_all(
-        format!(
-            "pub(crate) const SSID_SECURITY : &str = \"{}\";\n",
-            ssid.security
+            "\n\
+pub(crate) fn get_default_ssid_spec() -> SsidSpec {{ \n\
+    SsidSpec {{ \n\
+        ssid_name: String::from_str(\"{}\").unwrap(), \n\
+        ssid_pass: String::from_str(\"{}\").unwrap(), \n\
+        ssid_security: String::from_str(\"{}\").unwrap(), \n\
+    }} \n\
+}}",
+            ssid.ssid_name, ssid.ssid_pass, ssid.security
         )
         .as_bytes(),
     )

--- a/porky/memory.x
+++ b/porky/memory.x
@@ -1,17 +1,8 @@
 MEMORY {
     BOOT2 : ORIGIN = 0x10000000, LENGTH = 0x100
-    FLASH : ORIGIN = 0x10000100, LENGTH = 2048K - 0x100
-
-    /* Pick one of the two options for RAM layout     */
-
-    /* OPTION A: Use all RAM banks as one big block   */
-    /* Reasonable, unless you are doing something     */
-    /* really particular with DMA or other concurrent */
-    /* access that would benefit from striping        */
-    RAM   : ORIGIN = 0x20000000, LENGTH = 264K
-
-    /* OPTION B: Keep the unstriped sections separate */
-    /* RAM: ORIGIN = 0x20000000, LENGTH = 256K        */
-    /* SCRATCH_A: ORIGIN = 0x20040000, LENGTH = 4K    */
-    /* SCRATCH_B: ORIGIN = 0x20041000, LENGTH = 4K    */
+    FLASH : ORIGIN = 0x10000100, LENGTH = 1024K - LENGTH(BOOT2)
+    CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 256K
+    RAM   : ORIGIN = 0x20000000, LENGTH = 256K
 }
+
+__config_start = ORIGIN(CONFIG) - ORIGIN(BOOT2);

--- a/porky/src/flash.rs
+++ b/porky/src/flash.rs
@@ -1,25 +1,106 @@
-use crate::FLASH_SIZE;
 use core::str;
 use defmt::info;
-use embassy_rp::flash::{Async, Flash};
-use embassy_rp::peripherals::{DMA_CH1, FLASH};
+use ekv::flash::{self, PageID};
+use ekv::{config, Database};
+use embassy_rp::flash::{Blocking, Flash};
+use embassy_rp::peripherals::FLASH;
+use embassy_sync::blocking_mutex::raw::NoopRawMutex;
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use faster_hex::hex_encode;
 use static_cell::StaticCell;
+use {defmt_rtt as _, panic_probe as _};
+
+pub const FLASH_SIZE: usize = 2 * 1024 * 1024;
+
+extern "C" {
+    // Flash storage used for configuration
+    static __config_start: u32;
+}
+
+// Workaround for alignment requirements.
+#[repr(C, align(4))]
+struct AlignedBuf<const N: usize>([u8; N]);
+
+pub struct DbFlash<T: NorFlash + ReadNorFlash> {
+    start: usize,
+    flash: T,
+}
 
 /// Get the unique serial number from Flash
-pub fn serial_number(flash: FLASH, dma: DMA_CH1) -> &'static str {
+pub fn serial_number<'a>(flash: &mut Flash<'a, FLASH, Blocking, FLASH_SIZE>) -> &'static str {
     // Get a unique device id - in this case an eight-byte ID from flash rendered as hex string
-    let mut flash = Flash::<_, Async, { FLASH_SIZE }>::new(flash, dma);
     let mut device_id = [0; 8];
     flash.blocking_unique_id(&mut device_id).unwrap();
-    info!("device_id: {:?}", device_id);
 
     // convert the device_id to a hex "string"
     let mut device_id_hex: [u8; 16] = [0; 16];
     hex_encode(&device_id, &mut device_id_hex).unwrap();
 
-    info!("device_id: {}", device_id_hex);
     static ID: StaticCell<[u8; 16]> = StaticCell::new();
     let id = ID.init(device_id_hex);
-    str::from_utf8(id).unwrap()
+    let device_id_str = str::from_utf8(id).unwrap();
+    info!("device_id: {}", device_id_str);
+    device_id_str
+}
+
+impl<T: NorFlash + ReadNorFlash> flash::Flash for DbFlash<T> {
+    type Error = T::Error;
+
+    fn page_count(&self) -> usize {
+        config::MAX_PAGE_COUNT
+    }
+
+    async fn erase(&mut self, page_id: PageID) -> Result<(), <DbFlash<T> as flash::Flash>::Error> {
+        self.flash.erase(
+            (self.start + page_id.index() * config::PAGE_SIZE) as u32,
+            (self.start + page_id.index() * config::PAGE_SIZE + config::PAGE_SIZE) as u32,
+        )
+    }
+
+    async fn read(
+        &mut self,
+        page_id: PageID,
+        offset: usize,
+        data: &mut [u8],
+    ) -> Result<(), <DbFlash<T> as flash::Flash>::Error> {
+        let address = self.start + page_id.index() * config::PAGE_SIZE + offset;
+        let mut buf = AlignedBuf([0; config::PAGE_SIZE]);
+        self.flash.read(address as u32, &mut buf.0[..data.len()])?;
+        data.copy_from_slice(&buf.0[..data.len()]);
+        Ok(())
+    }
+
+    async fn write(
+        &mut self,
+        page_id: PageID,
+        offset: usize,
+        data: &[u8],
+    ) -> Result<(), <DbFlash<T> as flash::Flash>::Error> {
+        let address = self.start + page_id.index() * config::PAGE_SIZE + offset;
+        let mut buf = AlignedBuf([0; config::PAGE_SIZE]);
+        buf.0[..data.len()].copy_from_slice(data);
+        self.flash.write(address as u32, &buf.0[..data.len()])
+    }
+}
+
+pub fn get_flash<'a>(flash_pin: FLASH) -> Flash<'a, FLASH, Blocking, FLASH_SIZE> {
+    Flash::new_blocking(flash_pin)
+}
+
+pub async fn db_init<'a>(
+    flash: Flash<'a, FLASH, Blocking, FLASH_SIZE>,
+) -> Database<DbFlash<Flash<'a, FLASH, Blocking, FLASH_SIZE>>, NoopRawMutex> {
+    let flash: DbFlash<Flash<_, _, FLASH_SIZE>> = DbFlash {
+        flash,
+        start: unsafe { &__config_start as *const u32 as usize },
+    };
+    let db = Database::<_, NoopRawMutex>::new(flash, ekv::Config::default());
+
+    if db.mount().await.is_err() {
+        info!("Initializing Flash DB...");
+        db.format().await.unwrap();
+    }
+
+    info!("Flash Database is up");
+    db
 }

--- a/porky/src/flash.rs
+++ b/porky/src/flash.rs
@@ -1,0 +1,25 @@
+use crate::FLASH_SIZE;
+use core::str;
+use defmt::info;
+use embassy_rp::flash::{Async, Flash};
+use embassy_rp::peripherals::{DMA_CH1, FLASH};
+use faster_hex::hex_encode;
+use static_cell::StaticCell;
+
+/// Get the unique serial number from Flash
+pub fn serial_number(flash: FLASH, dma: DMA_CH1) -> &'static str {
+    // Get a unique device id - in this case an eight-byte ID from flash rendered as hex string
+    let mut flash = Flash::<_, Async, { FLASH_SIZE }>::new(flash, dma);
+    let mut device_id = [0; 8];
+    flash.blocking_unique_id(&mut device_id).unwrap();
+    info!("device_id: {:?}", device_id);
+
+    // convert the device_id to a hex "string"
+    let mut device_id_hex: [u8; 16] = [0; 16];
+    hex_encode(&device_id, &mut device_id_hex).unwrap();
+
+    info!("device_id: {}", device_id_hex);
+    static ID: StaticCell<[u8; 16]> = StaticCell::new();
+    let id = ID.init(device_id_hex);
+    str::from_utf8(id).unwrap()
+}

--- a/porky/src/porky.rs
+++ b/porky/src/porky.rs
@@ -115,7 +115,7 @@ fn hardware_description(serial: &str) -> HardwareDescription {
 /// Return the [SsidSpec] we should use to try and connect to the Wi-Fi network
 /// If we can find an override value stored in the flash database, use that.
 /// If not, use the default value that was built from `ssid.toml` file in project root folder
-async fn get_ssid_spec<'a>(
+pub async fn get_ssid_spec<'a>(
     db: &Database<DbFlash<Flash<'a, FLASH, Blocking, { flash::FLASH_SIZE }>>, NoopRawMutex>,
     buf: &'a mut [u8],
 ) -> SsidSpec<'a> {
@@ -233,15 +233,11 @@ async fn main(spawner: Spawner) {
     let ssid_spec = SSID_SPEC.init(spec);
 
     #[cfg(feature = "usb-raw")]
-    usb_raw::start(spawner, driver, hw_desc, ssid_spec).await;
+    usb_raw::start(spawner, driver, hw_desc, db).await;
 
     wifi::join(&mut control, wifi_stack, ssid_spec).await;
     let mut wifi_tx_buffer = [0; 4096];
     let mut wifi_rx_buffer = [0; 4096];
-
-    //let mut wtx = db.write_transaction().await;
-    //wtx.write(b"HELLO", b"WORLD").await.unwrap();
-    //wtx.commit().await.unwrap();
 
     loop {
         match tcp::wait_connection(

--- a/porky/src/usb_raw.rs
+++ b/porky/src/usb_raw.rs
@@ -76,8 +76,8 @@ impl<'h> Handler for ControlHandler<'h> {
                         );
                         Some(OutResponse::Accepted)
                     }
-                    Err(_) => {
-                        error!("Error storing SsidSpec to Flash Database");
+                    Err(e) => {
+                        error!("Error ({}) storing SsidSpec to Flash Database", e);
                         Some(OutResponse::Rejected)
                     }
                 }

--- a/porky/src/usb_raw.rs
+++ b/porky/src/usb_raw.rs
@@ -39,7 +39,7 @@ pub(crate) struct ControlHandler<'h> {
 
 /// Update the [SsidSpec] held by the [ControlHandler] and also write it to the flash database
 fn store_ssid_spec(_ssid_spec: &SsidSpec) {
-
+    // TODO store it
     /*
     let mut wtx = self.db.write_transaction().await;
     let bytes = postcard::to_slice(ssid_spec, &mut self.buf).unwrap();
@@ -65,9 +65,8 @@ impl<'h> Handler for ControlHandler<'h> {
         // Respond to valid requests from piggui
         match (req.request, req.value) {
             (PIGGUI_REQUEST, _SET_SSID_VALUE) => {
-                self.buf.clone_from_slice(&buf);
-                let ssid_spec = postcard::from_bytes::<SsidSpec>(&self.buf).ok()?;
-                self.ssid_spec = ssid_spec;
+                let _ssid_spec = postcard::from_bytes::<SsidSpec>(buf).ok()?;
+                // TODO store it!
                 store_ssid_spec(&self.ssid_spec);
                 info!("SsidSpec set via USB");
             }

--- a/porky/src/usb_raw.rs
+++ b/porky/src/usb_raw.rs
@@ -37,7 +37,7 @@ pub(crate) struct ControlHandler<'h> {
     buf: [u8; 1024],
 }
 
-/// Update the [SsidSpec] held by the [ControlHandler] and also write it to the flash database
+/// Write the [SsidSpec] to the flash database
 fn store_ssid_spec<'h>(
     _db: &mut Database<DbFlash<Flash<'h, FLASH, Blocking, { flash::FLASH_SIZE }>>, NoopRawMutex>,
     _ssid_spec: &SsidSpec,
@@ -71,7 +71,10 @@ impl<'h> Handler for ControlHandler<'h> {
                 self.ssid_spec = postcard::from_bytes::<SsidSpec>(buf).ok()?;
                 // TODO store it!
                 store_ssid_spec(&mut self.db, &self.ssid_spec);
-                info!("SsidSpec set via USB");
+                info!(
+                    "SsidSpec for SSID: {} set via USB",
+                    self.ssid_spec.ssid_name
+                );
             }
             (_, _) => {
                 error!(

--- a/porky/src/usb_raw.rs
+++ b/porky/src/usb_raw.rs
@@ -66,18 +66,8 @@ impl<'h> Handler for ControlHandler<'h> {
         match (req.request, req.value) {
             (PIGGUI_REQUEST, _SET_SSID_VALUE) => {
                 self.buf.clone_from_slice(&buf);
-                self.ssid_spec = postcard::from_bytes::<SsidSpec>(&self.buf).ok()?;
-                /*
-                                51 | impl<'h> Handler for ControlHandler<'h> {
-                   |      -- lifetime `'h` defined here
-                ...
-                54 |     fn control_out(&mut self, req: Request, buf: &[u8]) -> Option<OutResponse> {
-                   |                    - let's call the lifetime of this reference `'1`
-                ...
-                69 |                 self.ssid_spec = postcard::from_bytes::<SsidSpec>(&self.buf).ok()?;
-                   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'h`
-
-                                 */
+                let ssid_spec = postcard::from_bytes::<SsidSpec>(&self.buf).ok()?;
+                self.ssid_spec = ssid_spec;
                 store_ssid_spec(&self.ssid_spec);
                 info!("SsidSpec set via USB");
             }

--- a/porky/src/usb_raw.rs
+++ b/porky/src/usb_raw.rs
@@ -32,7 +32,7 @@ async fn usb_task(mut device: UsbDevice<'static, MyDriver>) -> ! {
 pub(crate) struct ControlHandler<'h> {
     if_num: InterfaceNumber,
     hardware_description: &'h HardwareDescription<'h>,
-    ssid_spec: SsidSpec<'h>,
+    ssid_spec: SsidSpec,
     db: Database<DbFlash<Flash<'h, FLASH, Blocking, { flash::FLASH_SIZE }>>, NoopRawMutex>,
     buf: [u8; 1024],
 }

--- a/porky/src/usb_raw.rs
+++ b/porky/src/usb_raw.rs
@@ -45,13 +45,21 @@ impl<'h> Handler for ControlHandler<'h> {
             return None;
         }
 
-        // Accept request 100, value 200, reject others.
-        if req.request == 100 && req.value == 200 {
-            info!("Message: {}", str::from_utf8(buf).unwrap());
-            Some(OutResponse::Accepted)
-        } else {
-            Some(OutResponse::Rejected)
-        }
+        // Respond to valid requests from piggui
+        match (req.request, req.value) {
+            (PIGGUI_REQUEST, SET_SSID_VALUE) => {
+                let _ssid_spec: SsidSpec = postcard::from_bytes(buf).ok()?;
+                info!("Requested to set ssid spec");
+            }
+            _ => {
+                error!(
+                    "Unknown USB request and/or value: {}:{}",
+                    req.request, req.value
+                );
+                return Some(OutResponse::Rejected);
+            }
+        };
+        Some(OutResponse::Accepted)
     }
 
     /// Respond to DeviceToHost control messages, where the host requests some data from us.

--- a/porky/src/wifi.rs
+++ b/porky/src/wifi.rs
@@ -69,14 +69,13 @@ pub async fn join(control: &mut Control<'_>, stack: Stack<'static>, wifi_spec: &
 
 /// Wait for the DHCP service to come up and for us to get an IP address
 pub(crate) async fn wait_for_dhcp(name: &str, stack: &Stack<'static>) {
-    info!("Waiting for DHCP on {}", name);
+    info!("Waiting for IP Address assignment {}", name);
     while !stack.is_config_up() {
         Timer::after_millis(100).await;
     }
-    info!("DHCP is up!");
     if let Some(if_config) = stack.config_v4() {
         let ip_address = if_config.address.address();
-        info!("{} IP: {}", name, ip_address);
+        info!("Assigned {} IP: {}", name, ip_address);
     }
 }
 

--- a/porky/src/wifi.rs
+++ b/porky/src/wifi.rs
@@ -28,7 +28,7 @@ async fn net_task(mut runner: embassy_net::Runner<'static, cyw43::NetDriver<'sta
     runner.run().await
 }
 
-pub async fn join(control: &mut Control<'_>, stack: Stack<'static>, wifi_spec: &SsidSpec<'_>) {
+pub async fn join(control: &mut Control<'_>, stack: Stack<'static>, wifi_spec: &SsidSpec) {
     let mut attempt = 1;
     while attempt <= WIFI_JOIN_RETRY_ATTEMPT_LIMIT {
         info!(
@@ -38,7 +38,7 @@ pub async fn join(control: &mut Control<'_>, stack: Stack<'static>, wifi_spec: &
 
         let mut join_options = JoinOptions::new(wifi_spec.ssid_pass.as_bytes());
 
-        match wifi_spec.ssid_security {
+        match wifi_spec.ssid_security.as_str() {
             "open" => join_options.auth = JoinAuth::Open,
             "wpa" => join_options.auth = JoinAuth::Wpa,
             "wpa2" => join_options.auth = JoinAuth::Wpa2,
@@ -48,7 +48,7 @@ pub async fn join(control: &mut Control<'_>, stack: Stack<'static>, wifi_spec: &
             }
         };
 
-        match control.join(wifi_spec.ssid_name, join_options).await {
+        match control.join(&wifi_spec.ssid_name, join_options).await {
             Ok(_) => {
                 info!("Joined wifi network: '{}'", wifi_spec.ssid_name);
                 wait_for_dhcp("WiFi", &stack).await;

--- a/src/hw_definition/config.rs
+++ b/src/hw_definition/config.rs
@@ -1,20 +1,23 @@
 use crate::hw_definition::pin_function::PinFunction;
 use crate::hw_definition::{BCMPinNumber, PinLevel};
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use heapless::FnvIndexMap;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::collections::HashMap;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::time::Duration;
 
 /// [HardwareConfig] captures the current configuration of programmable GPIO pins
-#[cfg_attr(feature = "std", derive(Debug, Clone, Serialize, Deserialize, Default))]
-#[cfg_attr(not(feature = "std"), derive(Clone, Serialize, Deserialize))]
+#[cfg_attr(
+    not(feature = "no_std"),
+    derive(Debug, Clone, Serialize, Deserialize, Default)
+)]
+#[cfg_attr(feature = "no_std", derive(Clone, Serialize, Deserialize))]
 pub struct HardwareConfig {
-    #[cfg(feature = "std")]
+    #[cfg(not(feature = "no_std"))]
     pub pin_functions: HashMap<BCMPinNumber, PinFunction>,
-    #[cfg(not(feature = "std"))]
+    #[cfg(feature = "no_std")]
     pub pin_functions: FnvIndexMap<BCMPinNumber, PinFunction, 32>,
 }
 
@@ -23,8 +26,8 @@ pub struct HardwareConfig {
 ///    * NewConfig
 ///    * NewPinConfig
 ///    * OutputLevelChanged
-#[cfg_attr(feature = "std", derive(Debug, Clone, Serialize, Deserialize))]
-#[cfg_attr(not(feature = "std"), derive(Clone, Serialize, Deserialize))]
+#[cfg_attr(not(feature = "no_std"), derive(Debug, Clone, Serialize, Deserialize))]
+#[cfg_attr(feature = "no_std", derive(Clone, Serialize, Deserialize))]
 pub enum HardwareConfigMessage {
     /// A complete new hardware config has been loaded and applied to the hardware, so we should
     /// start listening for level changes on each of the input pins it contains
@@ -35,14 +38,14 @@ pub enum HardwareConfigMessage {
     IOLevelChanged(BCMPinNumber, LevelChange),
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Duration {
     pub secs: u64,
     pub nanos: u32,
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 impl From<embassy_time::Duration> for Duration {
     fn from(duration: embassy_time::Duration) -> Self {
         Duration {
@@ -52,7 +55,7 @@ impl From<embassy_time::Duration> for Duration {
     }
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 impl From<Duration> for embassy_time::Duration {
     fn from(duration: Duration) -> Self {
         embassy_time::Duration::from_nanos((duration.secs * 1_000_000_000) + duration.nanos as u64)
@@ -62,7 +65,7 @@ impl From<Duration> for embassy_time::Duration {
 /// LevelChange describes the change in level of an input or Output and when it occurred
 /// - `new_level` : [PinLevel]
 /// - `timestamp` : [Duration]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[cfg_attr(not(feature = "no_std"), derive(Debug))]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LevelChange {
     pub new_level: PinLevel,

--- a/src/hw_definition/description.rs
+++ b/src/hw_definition/description.rs
@@ -8,11 +8,18 @@ use std::borrow::Cow;
 use std::string::String;
 
 #[cfg(feature = "no_std")]
+use heapless::String;
+#[cfg(feature = "no_std")]
 use heapless::Vec;
 #[cfg(not(feature = "no_std"))]
 use std::vec::Vec;
 
 use crate::hw_definition::pin_function::PinFunction;
+
+#[cfg(feature = "no_std")]
+const SSID_NAME_LENGTH: usize = 32;
+#[cfg(feature = "no_std")]
+const SSID_PASS_LENGTH: usize = 63;
 
 /// [HardwareDescription] contains details about the board we are running on and the GPIO pins
 #[cfg(not(feature = "no_std"))]
@@ -70,10 +77,10 @@ pub struct SsidSpec {
 #[cfg(feature = "no_std")]
 /// [SsidSpec] contains details on how the device connects to Wi-Fi
 #[derive(Serialize, Deserialize)]
-pub struct SsidSpec<'a> {
-    pub ssid_name: &'a str,
-    pub ssid_pass: &'a str,
-    pub ssid_security: &'a str,
+pub struct SsidSpec {
+    pub ssid_name: String<SSID_NAME_LENGTH>,
+    pub ssid_pass: String<SSID_PASS_LENGTH>,
+    pub ssid_security: String<4>,
 }
 
 #[cfg(not(feature = "no_std"))]
@@ -89,7 +96,7 @@ pub struct WiFiDetails {
 /// [WiFiDetails] contains details on WiFi connection and connections details
 #[derive(Serialize)]
 pub struct WiFiDetails<'a> {
-    ssid_spec: SsidSpec<'a>,
+    ssid_spec: SsidSpec,
     tcp: (&'a str, u16), // ("ip", port)
     iroh: &'a str,       // "NodeId"
 }

--- a/src/hw_definition/description.rs
+++ b/src/hw_definition/description.rs
@@ -1,37 +1,37 @@
 use serde::{Deserialize, Serialize};
 
 use crate::hw_definition::{BCMPinNumber, BoardPinNumber};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::borrow::Cow;
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::string::String;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 use heapless::Vec;
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 use std::vec::Vec;
 
 use crate::hw_definition::pin_function::PinFunction;
 
 /// [HardwareDescription] contains details about the board we are running on and the GPIO pins
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 #[derive(Serialize)]
-#[cfg_attr(feature = "std", derive(Debug, Clone, Deserialize))]
+#[cfg_attr(not(feature = "no_std"), derive(Debug, Clone, Deserialize))]
 pub struct HardwareDescription {
     pub details: HardwareDetails,
     pub pins: PinDescriptionSet,
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 #[derive(Serialize)]
-#[cfg_attr(feature = "std", derive(Debug, Clone, Deserialize))]
+#[cfg_attr(not(feature = "no_std"), derive(Debug, Clone, Deserialize))]
 pub struct HardwareDescription<'a> {
     pub details: HardwareDetails<'a>,
     pub pins: PinDescriptionSet<'a>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 /// [HardwareDetails] captures a number of specific details about the Hardware we are connected to
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HardwareDetails {
@@ -47,7 +47,7 @@ pub struct HardwareDetails {
     pub wifi: bool,
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 /// [HardwareDetails] captures a number of specific details about the Hardware we are connected to
 #[derive(Serialize)]
 pub struct HardwareDetails<'a> {
@@ -58,8 +58,8 @@ pub struct HardwareDetails<'a> {
     pub wifi: bool,
 }
 
-#[cfg(feature = "std")]
-/// [SsidSpec] contains details on how the device connects to WiFi
+#[cfg(not(feature = "no_std"))]
+/// [SsidSpec] contains details on how the device connects to Wi-Fi
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SsidSpec {
     pub ssid_name: String,
@@ -67,8 +67,8 @@ pub struct SsidSpec {
     pub ssid_security: String,
 }
 
-#[cfg(not(feature = "std"))]
-/// [SsidSpec] contains details on how the device connects to WiFi
+#[cfg(feature = "no_std")]
+/// [SsidSpec] contains details on how the device connects to Wi-Fi
 #[derive(Serialize, Deserialize)]
 pub struct SsidSpec<'a> {
     pub ssid_name: &'a str,
@@ -76,7 +76,7 @@ pub struct SsidSpec<'a> {
     pub ssid_security: &'a str,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 /// [WiFiDetails] contains details on WiFi connection and connections details
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WiFiDetails {
@@ -85,7 +85,7 @@ pub struct WiFiDetails {
     iroh: String,       // "NodeId"
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 /// [WiFiDetails] contains details on WiFi connection and connections details
 #[derive(Serialize)]
 pub struct WiFiDetails<'a> {
@@ -94,7 +94,7 @@ pub struct WiFiDetails<'a> {
     iroh: &'a str,       // "NodeId"
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 /// [PinDescription] describes a pins in the connected hardware.
 /// Array indexed from 0 so, index = board_pin_number -1, as pin numbering start at 1
 #[derive(Serialize, Debug, Clone, Deserialize)]
@@ -102,7 +102,7 @@ pub struct PinDescriptionSet {
     pub(crate) pins: Vec<PinDescription>,
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 /// [PinDescription] describes a pins in the connected hardware.
 /// Array indexed from 0 so, index = board_pin_number -1, as pin numbering start at 1
 #[derive(Serialize)]
@@ -110,7 +110,7 @@ pub struct PinDescriptionSet<'a> {
     pub(crate) pins: Vec<PinDescription<'a>, 40>,
 }
 
-#[cfg(feature = "std")]
+#[cfg(not(feature = "no_std"))]
 /// [PinDescription] is used to describe each pin and possible uses it can be put to
 /// * [board_pin_number] refer to the pins by the number of the pin printed on the board
 /// * [bcm_pin_number] refer to the pins by the "Broadcom SOC channel" number. Programmable pins
@@ -125,7 +125,7 @@ pub struct PinDescription {
     pub options: Cow<'static, [PinFunction]>,
 }
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "no_std")]
 #[derive(Clone, Serialize)]
 pub struct PinDescription<'a> {
     pub bpn: BoardPinNumber,

--- a/src/hw_definition/description.rs
+++ b/src/hw_definition/description.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "std")]
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::hw_definition::{BCMPinNumber, BoardPinNumber};
 #[cfg(feature = "std")]
@@ -71,7 +69,7 @@ pub struct SsidSpec {
 
 #[cfg(not(feature = "std"))]
 /// [SsidSpec] contains details on how the device connects to WiFi
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SsidSpec<'a> {
     pub ssid_name: &'a str,
     pub ssid_pass: &'a str,

--- a/src/hw_definition/usb_requests.rs
+++ b/src/hw_definition/usb_requests.rs
@@ -8,3 +8,6 @@ pub const GET_HARDWARE_VALUE: u16 = 201;
 
 /// Command value to get the ssid details from porky
 pub const GET_SSID_VALUE: u16 = 202;
+
+/// Command value to set the ssid details from porky
+pub const SET_SSID_VALUE: u16 = 203;

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -189,7 +189,7 @@ impl Piggui {
                         &self.hardware_view,
                     );
                 } else {
-                    return Task::batch(vec![pick_and_load()]);
+                    return pick_and_load();
                 }
             }
 
@@ -261,15 +261,19 @@ impl Piggui {
 
             Device(event) => self.device_event(event),
 
-            ConfigureWiFi(serial_number, ssid_spec) => {
-                println!(
-                    "dialog to configure known device with serial number: {}",
-                    serial_number
-                )
+            ConfigureWiFi(hardware_details, ssid_spec) => {
+                return Self::send_ssid(hardware_details, ssid_spec);
             }
         }
 
         Task::none()
+    }
+
+    fn send_ssid(hardware_details: HardwareDetails, ssid_spec: Option<SsidSpec>) -> Task<Message> {
+        Task::perform(
+            usb_raw::send_ssid_spec(hardware_details.serial, ssid_spec.unwrap()),
+            |_| Message::MenuBarButtonClicked, // TODO
+        )
     }
 
     /*

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -23,6 +23,7 @@ use crate::views::connect_dialog_handler::{
     ConnectDialog, ConnectDialogMessage, ConnectDialogMessage::HideConnectDialog,
 };
 use crate::views::hardware_menu;
+use crate::views::message_box::MessageRowMessage::ShowStatusMessage;
 #[cfg(feature = "iroh")]
 use iroh_net::NodeId;
 #[cfg(any(feature = "iroh", feature = "tcp"))]
@@ -272,7 +273,7 @@ impl Piggui {
     fn send_ssid(hardware_details: HardwareDetails, ssid_spec: Option<SsidSpec>) -> Task<Message> {
         Task::perform(
             usb_raw::send_ssid_spec(hardware_details.serial, ssid_spec.unwrap()),
-            |_| Message::MenuBarButtonClicked, // TODO
+            |_| InfoRow(ShowStatusMessage(Info("Wi-Fi Setup sent via USB".into()))),
         )
     }
 

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -17,6 +17,7 @@ use views::pin_state::PinState;
 
 use crate::views::hardware_menu::{DeviceEvent, KnownDevice};
 
+use crate::hw_definition::description::{HardwareDetails, SsidSpec};
 #[cfg(any(feature = "iroh", feature = "tcp"))]
 use crate::views::connect_dialog_handler::{
     ConnectDialog, ConnectDialogMessage, ConnectDialogMessage::HideConnectDialog,
@@ -67,7 +68,7 @@ pub enum Message {
     ConnectionError(String),
     MenuBarButtonClicked,
     Device(DeviceEvent),
-    ConfigureWiFi(String),
+    ConfigureWiFi(HardwareDetails, Option<SsidSpec>),
 }
 
 /// [Piggui] Is the struct that holds application state and implements [Application] for Iced
@@ -260,7 +261,7 @@ impl Piggui {
 
             Device(event) => self.device_event(event),
 
-            ConfigureWiFi(serial_number) => {
+            ConfigureWiFi(serial_number, ssid_spec) => {
                 println!(
                     "dialog to configure known device with serial number: {}",
                     serial_number

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -263,6 +263,9 @@ impl Piggui {
             Device(event) => self.device_event(event),
 
             ConfigureWiFi(hardware_details, ssid_spec) => {
+                // TODO this should show the dialog, and the dialog submit will send a new message
+                // like "SendWifiConfig(serial_number, ssid_spec) and that message should call
+                // this method to send it via USB to the attached porky
                 return Self::send_ssid(hardware_details, ssid_spec);
             }
         }

--- a/src/piggui.rs
+++ b/src/piggui.rs
@@ -23,6 +23,7 @@ use crate::views::connect_dialog_handler::{
     ConnectDialog, ConnectDialogMessage, ConnectDialogMessage::HideConnectDialog,
 };
 use crate::views::hardware_menu;
+#[cfg(feature = "usb-raw")]
 use crate::views::message_box::MessageRowMessage::ShowStatusMessage;
 #[cfg(feature = "iroh")]
 use iroh_net::NodeId;
@@ -273,11 +274,15 @@ impl Piggui {
         Task::none()
     }
 
+    #[allow(unused_variables)]
     fn send_ssid(hardware_details: HardwareDetails, ssid_spec: Option<SsidSpec>) -> Task<Message> {
-        Task::perform(
+        #[cfg(feature = "usb-raw")]
+        return Task::perform(
             usb_raw::send_ssid_spec(hardware_details.serial, ssid_spec.unwrap()),
             |_| InfoRow(ShowStatusMessage(Info("Wi-Fi Setup sent via USB".into()))),
-        )
+        );
+        #[cfg(not(feature = "usb-raw"))]
+        Task::none()
     }
 
     /*

--- a/src/usb_raw.rs
+++ b/src/usb_raw.rs
@@ -94,7 +94,7 @@ async fn get_ssid_spec(porky: &Interface) -> Result<SsidSpec, String> {
 }
 
 /// Send a new Wi-Fi SsidSpec to the connected porky device
-pub async fn send_ssid_spec(serial_number: &str, ssid_spec: &SsidSpec) -> Result<(), String> {
+pub async fn send_ssid_spec(serial_number: String, ssid_spec: SsidSpec) -> Result<(), String> {
     let porky = find_porky().ok_or("Could not find USB attached porky")?;
 
     let hardware_description = get_hardware_description(&porky).await?;

--- a/src/views/hardware_menu.rs
+++ b/src/views/hardware_menu.rs
@@ -40,7 +40,6 @@ pub enum DeviceEvent {
 }
 
 pub enum KnownDevice {
-    #[allow(dead_code)] // Until ssid spec is used
     Porky(DiscoveryMethod, HardwareDescription, Option<SsidSpec>),
 }
 
@@ -52,7 +51,7 @@ fn devices_submenu<'a>(
 
     for (serial_number, device) in known_devices {
         match device {
-            Porky(method, hardware_description, _) => {
+            Porky(method, hardware_description, ssid_spec) => {
                 let button = Button::new(Text::new(format!(
                     "{} ({}) {}",
                     hardware_description.details.model, serial_number, method
@@ -72,7 +71,10 @@ fn devices_submenu<'a>(
                         button,
                         Menu::new(vec![Item::new(
                             Button::new(Text::new("Configure Device WiFi"))
-                                .on_press(Message::ConfigureWiFi(serial_number.to_string()))
+                                .on_press(Message::ConfigureWiFi(
+                                    hardware_description.details.clone(),
+                                    ssid_spec.clone(),
+                                ))
                                 .width(170.0)
                                 .style(|_, status| {
                                     if status == Hovered {


### PR DESCRIPTION
- [ ] implement a dialog for configuring the wifi (SsidSpec) of a USB connected Porky.
- [ ] this should be opened by the `ConfigureWiFi(HardwareDetails, Option<SsidSpec>)` message (exists in update() already)
- [ ] the model and the serial number in the HardwareDetails should be displayed to know which device is being configured
- [ ] The dialog shoul dhave fields for SSID Name, Password (a password field!), and security setting (wpa, etc)
- [ ] Those maybe supplied in the optional SsidSpec in the message. If they are supplied then the fields should be pre-fileld with that data
- [ ] the name should be visible field and editable
- [ ] the password field should have a "show" checkbox to show the password or hide it showing '*'s
- [ ] these are the security options implemented by porky:
   -       "open" => join_options.auth = JoinAuth::Open,
            "wpa" => join_options.auth = JoinAuth::Wpa,
            "wpa2" => join_options.auth = JoinAuth::Wpa2,
            "wpa3" => join_options.auth = JoinAuth::Wpa3,

- [ ] If there is a way to do it, we should try and confirm the expected length of the password, and not activate COnfigure button unless it matches.
- [ ] we should try and check it is a valid password being entered
- [ ] We should have security be a pick list with those options, that generates those string equivalents into the SsidSpec.
- [ ] The dialog should have the same styles as the existing ones
- [ ] it will need a hidden error text field like the connect dialog
- [ ] it should have a cancel close button
- [ ] it should have a "submit" Config button
- [ ] when the submit action is done, it should send a message and the async fn `usb_raw::pub async fn send_ssid_spec(serial_number: &str, ssid_spec: &SsidSpec) -> Result<(), String>`should be called, sending the serial number we got, and the SsidSpec generated from the form fields.
- [ ] if that succeeds (Ok) then we clsoe the dialog
- [ ] if it fails, we show the error text in red and leave the dialog open

Add tests for as much of that as we can....
