### PR TITLE
Fix definition of GP0 and GP1 pins on Pi Pico W

### DIFF
--- a/porky/src/pin_descriptions.rs
+++ b/porky/src/pin_descriptions.rs
@@ -17,6 +17,7 @@ const PIN_1: PinDescription = PinDescription {
     name: "GP0",
     options: &[
         PinFunction::Output(None),
+        PinFunction::Input(Some(InputPull::PullUp)),
         // SPI0 RX
         // I2C0 SDA
         // UART0 TX
@@ -38,6 +39,7 @@ const PIN_2: PinDescription = PinDescription {
     name: "GP1",
     options: &[
         PinFunction::Output(None),
+        PinFunction::Input(Some(InputPull::PullUp)),
         // SPI0 SCL
         // I2C0 SCL
         // UART0 RX


### PR DESCRIPTION
Fixes #660 