### PR TITLE
fix_timestamps

### DIFF
--- a/porky/src/usb.rs
+++ b/porky/src/usb.rs
@@ -99,9 +99,7 @@ pub(crate) struct ControlHandler<'h> {
     watchdog: Watchdog,
 }
 
-impl<'h> ControlHandler<'h> {}
-
-impl<'h> Handler for ControlHandler<'h> {
+impl Handler for ControlHandler<'_> {
     #[allow(unused_variables)] // TODO for now as not used in non-wifi yet
     /// Respond to HostToDevice control messages, where the host sends us a command and
     /// optionally some data, and we can only acknowledge or reject it.

--- a/src/hw_definition/config.rs
+++ b/src/hw_definition/config.rs
@@ -53,7 +53,7 @@ impl From<embassy_time::Duration> for Duration {
     fn from(duration: embassy_time::Duration) -> Self {
         Duration {
             secs: duration.as_secs(),
-            nanos: duration.as_millis() as u32 * 1000,
+            nanos: ((duration.as_micros() % 1_000_000) * 1000) as u32,
         }
     }
 }


### PR DESCRIPTION
Fix the conversion of timestamps and avoid sending two consecutive values the same
Fixes #654 