### PR TITLE
Add running hw tests on self-hosted runner to the workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -152,9 +152,8 @@ jobs:
         run: cd porky && RUSTFLAGS= make uf2
 
   hw_tests:
-    #runs-on: pigg_hw_tests
     runs-on: [ self-hosted, macOS, ARM64, pigg ]
-    timeout-minutes: 15
+    timeout-minutes: 10 # test it times out
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -151,6 +151,15 @@ jobs:
       - name: Build porky and porky_w and their UF2 files
         run: cd porky && RUSTFLAGS= make uf2
 
+  hw_tests:
+    runs-on: pigg_hw_tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run HW Tests
+        run: make hw_tests
+
   clippy-build-and-test-matrix:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -152,7 +152,8 @@ jobs:
         run: cd porky && RUSTFLAGS= make uf2
 
   hw_tests:
-    runs-on: pigg_hw_tests
+    #runs-on: pigg_hw_tests
+    runs-on: [ self-hosted, macOS, ARM64, pigg ]
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -153,12 +153,14 @@ jobs:
 
   hw_tests:
     runs-on: pigg_hw_tests
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Run HW Tests
         run: make hw_tests
+        continue-on-error: true
 
   clippy-build-and-test-matrix:
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test:
 
 .PHONY: hw_tests
 hw_tests:
-	cargo test --package hw_tests
+	cargo test --package hw_test
 
 .PHONY: features
 features:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ build-porky:
 test:
 	cargo test
 
-
 .PHONY: hw_tests
 hw_tests:
 	cargo test --package hw_tests


### PR DESCRIPTION
Add a step to the workflow that runs hw_tests on a self-hosted runner that has a porky attached