### PR TITLE
Don't output endpoint- verbose and not useful

### DIFF
--- a/pigglet/src/device_net/iroh_device.rs
+++ b/pigglet/src/device_net/iroh_device.rs
@@ -43,7 +43,6 @@ impl Display for IrohDevice {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "nodeid:{}", self.nodeid)?;
         writeln!(f, "relay URL:{}", self.relay_url)?;
-        writeln!(f, "Endpoint:{:?}", self.endpoint)?;
         Ok(())
     }
 }

--- a/pigglet/src/instance.rs
+++ b/pigglet/src/instance.rs
@@ -64,10 +64,10 @@ impl std::fmt::Display for InstanceInfo {
         writeln!(f, "{}", self.process_name)?;
         writeln!(f, "{}", self.pid)?;
         #[cfg(feature = "iroh")]
-        writeln!(f, "{}", self.iroh_info)?;
+        write!(f, "{}", self.iroh_info)?;
 
         #[cfg(feature = "tcp")]
-        writeln!(f, "{}", self.tcp_info)?;
+        write!(f, "{}", self.tcp_info)?;
 
         Ok(())
     }


### PR DESCRIPTION
Simplify contents of .info file