### PR TITLE
As either pico1 or pico2 is needed for a correct compile, this causes project load in IDEs to fail as neither is defined.

### DIFF
--- a/porky/.cargo/config.toml
+++ b/porky/.cargo/config.toml
@@ -2,8 +2,7 @@
 
 # Choose a default "cargo run" tool (see README for more info)
 # - probe-rs   - provides flashing and defmt via a hardware debugger, and stack unwind on panic
-# - picotool   - used while the pico2 was lacking probe-rs support
-#              - runner = "picotool load -u -v -x -t elf"
+# - picotool   - runner = "picotool load -u -v -x -t elf"
 # - elf2uf2-rs - loads firmware over USB when the rp2040 is in boot mode
 #              - runner = "elf2uf2-rs -d"
 

--- a/porky/Cargo.toml
+++ b/porky/Cargo.toml
@@ -13,7 +13,7 @@ name = "porky"
 path = "src/porky.rs"
 
 [features]
-default = []
+default = ["pico1"]
 pico1 = ["embassy-rp/rp2040"]
 pico2 = ["embassy-rp/rp235xa"]
 wifi = ["dep:cyw43", "discovery", "tcp"]

--- a/porky/Makefile
+++ b/porky/Makefile
@@ -14,34 +14,34 @@ features:
 	cargo build-all-features --target thumbv6m-none-eabi
 
 clippy:
-	cargo clippy --target thumbv6m-none-eabi --features "usb, wifi, pico1"
-	cargo clippy --target thumbv6m-none-eabi --features "usb, pico1"
-	cargo clippy --target thumbv8m.main-none-eabihf --features "usb, wifi, pico2"
-	cargo clippy --target thumbv8m.main-none-eabihf --features "usb, pico2"
+	cargo clippy --target thumbv6m-none-eabi --no-default-features --features "usb, wifi, pico1"
+	cargo clippy --target thumbv6m-none-eabi --no-default-features --features "usb, pico1"
+	cargo clippy --target thumbv8m.main-none-eabihf --no-default-features --features "usb, wifi, pico2"
+	cargo clippy --target thumbv8m.main-none-eabihf --no-default-features --features "usb, pico2"
 
 run-w:
-	cargo run --release --target thumbv6m-none-eabi --features "usb, wifi, pico1"
+	cargo run --release --target thumbv6m-none-eabi --no-default-features --features "usb, wifi, pico1"
 
 run-w2:
-	cargo run --release --target thumbv8m.main-none-eabihf --features "usb, wifi, pico2"
+	cargo run --release --target thumbv8m.main-none-eabihf --no-default-features --features "usb, wifi, pico2"
 
 run:
-	cargo run --release --target thumbv6m-none-eabi --features "usb, pico1"
+	cargo run --release --target thumbv6m-none-eabi --no-default-features --features "usb, pico1"
 
 run2:
-	cargo run --release --target thumbv8m.main-none-eabihf --features "usb, pico2"
+	cargo run --release --target thumbv8m.main-none-eabihf --no-default-features --features "usb, pico2"
 
 build-w:
-	cargo build --release --target thumbv6m-none-eabi --features "usb, wifi, pico1"
+	cargo build --release --target thumbv6m-none-eabi --no-default-features --features "usb, wifi, pico1"
 
 build-w2:
-	cargo build --release --target thumbv8m.main-none-eabihf --features "usb, wifi, pico2"
+	cargo build --release --target thumbv8m.main-none-eabihf --no-default-features --features "usb, wifi, pico2"
 
 build:
-	cargo build --release --target thumbv6m-none-eabi --features "usb, pico1"
+	cargo build --release --target thumbv6m-none-eabi --no-default-features --features "usb, pico1"
 
 build2:
-	cargo build --release --target thumbv8m.main-none-eabihf --features "usb, pico2"
+	cargo build --release --target thumbv8m.main-none-eabihf --no-default-features --features "usb, pico2"
 
 install-binstall:
 	curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash


### PR DESCRIPTION
Fix project load from tools, where neither pico1 nor pico2 will be defined.