### PR TITLE
Move hw_tests to separate job that runs without profiling and not every day

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -205,15 +205,6 @@ jobs:
         run: |
           RUSTFLAGS= make -C porky build-uf2s
 
-  hw_tests:
-    runs-on: [ self-hosted, macOS, ARM64, pigg ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run HW Tests
-        run: make hw_tests
-
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/device_tests.yml
+++ b/.github/workflows/device_tests.yml
@@ -1,0 +1,23 @@
+name: Build and Test with Coverage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  hw_tests:
+    runs-on: [ self-hosted, macOS, ARM64, pigg ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run HW Tests
+        run: make hw_tests

--- a/porky/Cargo.lock
+++ b/porky/Cargo.lock
@@ -1567,9 +1567,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1577,18 +1577,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
hw_tests were being run with binaries with profiling info, leaving files around in runner.

Plus no need to do hw_tests every day