### PR TITLE
Fix browser/wasm build rendering and connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3263,6 +3269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4085,6 +4101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4273,6 +4295,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "tokio",
+ "wasm-bindgen-test",
  "wayland-sys",
  "webbrowser",
 ]
@@ -6326,6 +6349,45 @@ checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
 
 [[package]]
 name = "wasm-encoder"

--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,13 @@ coverage: clean-start
 	@genhtml -o target/coverage --quiet coverage.info
 	@echo "View coverage report using 'open target/coverage/index.html'"
 
+.PHONY: build-web
 build-web:
-	@make -C piggui trunk-build
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk build --release --config piggui/Trunk.toml
+
+.PHONY: web-run
+web-run: build-web
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk serve --release --config piggui/Trunk.toml
 
 docs:
 	bundle exec jekyll build --source site --destination _site

--- a/piggui/Cargo.toml
+++ b/piggui/Cargo.toml
@@ -54,37 +54,40 @@ serde_json = { version = "1.0.149", default-features = false, features = ["std"]
 
 iroh = { version = "1.0.0-rc.0", default-features = false, features = ["tls-ring"], optional = true }
 mdns-sd = { version = "0.17.1", default-features = false, features = ["async", "reuseport"], optional = true }
-sysinfo = { version = "0.39" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+sysinfo = { version = "0.39" }
 rfd = "0.17.2"
 clap = { version = "4.6.1", default-features = false, features = ["std", "help", "error-context"] }
 piggpio = { path = "../piggpio", version = "0.7" }
 
-# wasm32 - Use 'tiny-skia' renderer in iced
+# wasm32 - Use 'tiny-skia' software renderer in iced
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
-iced = { version = "0.14.0", default-features = false, features = ["tokio", "tiny-skia", "advanced", "canvas"] }
+iced = { version = "0.14.0", default-features = false, features = ["tokio", "tiny-skia", "fira-sans", "advanced", "canvas"] }
 
 # Raspberry Pi - Use 'tiny-skia' renderer in iced
 [target.'cfg(all(not(target_arch = "wasm32"), any(all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "arm", target_os = "linux"))))'.dependencies]
-iced = { version = "0.14.0", default-features = false, features = ["tokio", "tiny-skia", "advanced", "canvas", "x11", "wayland"] }
+iced = { version = "0.14.0", default-features = false, features = ["tokio", "tiny-skia", "fira-sans", "advanced", "canvas", "x11", "wayland"] }
 wayland-sys = { version = "0.31.11", features = ["dlopen"] }
 
 # Non-Raspberry Pi, Non-Windows - use 'wgpu' renderer in iced with x11/wayland
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "windows"), not(any(all(target_arch = "aarch64", target_os = "linux"), all(target_arch = "arm", target_os = "linux")))))'.dependencies]
-iced = { version = "0.14.0", default-features = false, features = ["tokio", "wgpu", "canvas", "advanced", "x11", "wayland"] }
+iced = { version = "0.14.0", default-features = false, features = ["tokio", "wgpu", "fira-sans", "canvas", "advanced", "x11", "wayland"] }
 wayland-sys = { version = "0.31.11", features = ["dlopen"] }
 
 # Windows - use 'wgpu' renderer in iced without x11/wayland
 [target.'cfg(target_os = "windows")'.dependencies]
-iced = { version = "0.14.0", default-features = false, features = ["tokio", "wgpu", "canvas", "advanced"] }
+iced = { version = "0.14.0", default-features = false, features = ["tokio", "wgpu", "fira-sans", "canvas", "advanced"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = "3"
 serial_test = "3.4.0"
 sysinfo = { version = "0.39" }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [dev-dependencies] # For tests
 pignet = { path = "../pignet", version = "0.7" }
@@ -99,5 +102,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.trunk.build]
 target = "index.html"
 dist = "dist"
-no_default_features = false
+no_default_features = true
 

--- a/piggui/Makefile
+++ b/piggui/Makefile
@@ -180,8 +180,8 @@ ssh:
 
 .PHONY: trunk-build
 trunk-build:
-	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk build
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk build --release
 
 .PHONY: web-run
 web-run: trunk-build
-	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk serve
+	RUSTFLAGS='--cfg getrandom_backend="wasm_js"' trunk serve --release

--- a/piggui/index.html
+++ b/piggui/index.html
@@ -5,8 +5,47 @@
     <meta content="width=device-width, initial-scale=1" name="viewport"/>
     <title>Piggui - Web</title>
     <base data-trunk-public-url/>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+        canvas {
+            width: 100% !important;
+            height: 100vh !important;
+        }
+    </style>
 </head>
 <body>
 <link data-bin="piggui" data-trunk data-wasm-opt="z" href="Cargo.toml" rel="rust"/>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const observer = new MutationObserver(() => {
+            const canvas = document.querySelector('canvas');
+            if (!canvas || canvas._pasteHooked) return;
+            canvas._pasteHooked = true;
+            canvas.addEventListener('keydown', (e) => {
+                if ((e.metaKey || e.ctrlKey) && e.key === 'v') {
+                    e.stopImmediatePropagation();
+                    e.preventDefault();
+                    navigator.clipboard.readText().then(text => {
+                        for (const char of text) {
+                            canvas.dispatchEvent(new KeyboardEvent('keydown', {
+                                key: char, bubbles: true, composed: true
+                            }));
+                            canvas.dispatchEvent(new KeyboardEvent('keyup', {
+                                key: char, bubbles: true, composed: true
+                            }));
+                        }
+                    });
+                }
+            }, true);
+        });
+        observer.observe(document.body, { childList: true });
+    });
+</script>
 </body>
 </html>

--- a/piggui/src/piggui.rs
+++ b/piggui/src/piggui.rs
@@ -58,6 +58,7 @@ mod local_host;
 mod views;
 mod widgets;
 
+#[cfg(not(target_arch = "wasm32"))]
 const PIGGUI_ID: &str = "piggui";
 const CONNECTION_ERROR: &str = "Error: Connecting";
 #[cfg(feature = "discovery")]
@@ -114,23 +115,27 @@ pub struct Piggui {
 fn main() -> iced::Result {
     #[cfg(target_arch = "wasm32")]
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-
     let settings = Settings {
+        #[cfg(not(target_arch = "wasm32"))]
         id: Some(PIGGUI_ID.into()),
         default_text_size: Pixels(14.0),
         ..Default::default()
     };
 
-    iced::application(Piggui::new, Piggui::update, Piggui::view)
+    let app = iced::application(Piggui::new, Piggui::update, Piggui::view)
         .subscription(Piggui::subscription)
         .window_size((500.0, 800.0))
-        .exit_on_close_request(false)
-        .resizable(true)
         .settings(settings)
-        .window_size(LayoutSelector::get_default_window_size())
         .theme(Theme::Dark)
-        .title(Piggui::title)
-        .run()
+        .title(Piggui::title);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let app = app
+        .window_size(LayoutSelector::get_default_window_size())
+        .exit_on_close_request(false)
+        .resizable(true);
+
+    app.run()
 }
 
 #[cfg(feature = "usb")]
@@ -688,3 +693,6 @@ fn get_matches() -> ArgMatches {
 
 #[cfg(test)]
 mod ui_test;
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_test;

--- a/piggui/src/views/connection_menu.rs
+++ b/piggui/src/views/connection_menu.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "iroh", feature = "tcp"))]
+use crate::views::connect_dialog::ConnectDialogMessage;
 use crate::views::hardware_view::HardwareView;
 use crate::views::info_dialog::InfoDialogMessage::HardwareDetailsModal;
 use crate::views::info_row::{menu_bar_button, menu_button_style};
@@ -13,6 +15,18 @@ pub fn view<'a>(hardware_view: &'a HardwareView) -> Item<'a, Message, Theme, Ren
     let mut menu_items: Vec<Item<'a, Message, _, _>> = vec![];
 
     let connection_string = if hardware_view.get_hardware_connection() == &NoConnection {
+        #[cfg(any(feature = "iroh", feature = "tcp"))]
+        {
+            let connect = Item::new(
+                button("Connect to remote Pi ...")
+                    .on_press(Message::ConnectDialog(
+                        ConnectDialogMessage::ShowConnectDialog,
+                    ))
+                    .width(Length::Fill)
+                    .style(menu_button_style),
+            );
+            menu_items.push(connect);
+        }
         "disconnected".to_string()
     } else if let Some(hardware_description) = hardware_view.get_description() {
         let show_details = Item::new(

--- a/piggui/src/views/hardware_view.rs
+++ b/piggui/src/views/hardware_view.rs
@@ -361,12 +361,18 @@ impl HardwareView {
 
     /// Draw an empty view when there is no connection to hardware
     pub fn empty_layout_view<'a>() -> Element<'a, HardwareViewMessage> {
-        let col = Column::new()
+        let mut col = Column::new()
             .width(Fill)
             .push(text("Disconnected").size(20))
-            .push(text("You are not currently connected to any device with GPIO hardware to display"))
-            .push(text("You can use the 'device' menu at the bottom of the window to connect to detected devices"))
-            .push(text("If you know the TCP or Iroh connection data, you can use the 'disconnected:' menu and the 'Connect to remote Pi ...' option"))
+            .push(text(
+                "You are not currently connected to any device with GPIO hardware to display",
+            ));
+        #[cfg(feature = "discovery")]
+        {
+            col = col.push(text("You can use the 'device' menu at the bottom of the window to connect to detected devices"));
+        }
+        col = col
+            .push(text("You can use the 'disconnected:' menu and the 'Connect to remote Pi ...' option to connect"))
             .spacing(SPACE_BETWEEN_PIN_ROWS)
             .align_x(Center);
 

--- a/piggui/src/views/layout_menu.rs
+++ b/piggui/src/views/layout_menu.rs
@@ -34,6 +34,7 @@ impl LayoutSelector {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub const fn get_default_window_size() -> Size {
         board_layout_size(40)
     }

--- a/piggui/src/wasm_test.rs
+++ b/piggui/src/wasm_test.rs
@@ -1,0 +1,66 @@
+use super::*;
+use crate::hardware_subscription::SubscriptionEvent;
+use crate::views::hardware_view::HardwareViewMessage::SubscriptionMessage;
+use pigdef::config::HardwareConfig;
+use pignet::HardwareConnection::NoConnection;
+use std::collections::HashMap;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn test_piggui() -> Piggui {
+    Piggui {
+        config_filename: None,
+        layout_selector: LayoutSelector::new(),
+        unsaved_changes: false,
+        info_row: InfoRow::new(),
+        modal_handler: InfoDialog::new(),
+        hardware_view: HardwareView::new(NoConnection),
+        #[cfg(any(feature = "iroh", feature = "tcp"))]
+        connect_dialog: ConnectDialog::new(),
+        #[cfg(feature = "discovery")]
+        discovered_devices: HashMap::new(),
+        #[cfg(feature = "usb")]
+        ssid_dialog: SsidDialog::new(),
+    }
+}
+
+fn test_piggui_connected() -> Piggui {
+    let hw = piggpio::HW::new();
+    let hw_desc = hw.description().clone();
+    let hw_config = HardwareConfig::default();
+
+    let mut app = test_piggui();
+    let _ = app
+        .hardware_view
+        .update(SubscriptionMessage(SubscriptionEvent::Connected(
+            hw_desc, hw_config,
+        )));
+    let _ = app.update(Message::Connected);
+    app
+}
+
+#[wasm_bindgen_test]
+fn app_initializes_in_wasm() {
+    let app = test_piggui();
+    assert!(app.hardware_view.get_description().is_none());
+    assert!(!app.unsaved_changes);
+}
+
+#[wasm_bindgen_test]
+fn app_connects_to_fake_hardware_in_wasm() {
+    let app = test_piggui_connected();
+    assert!(app.hardware_view.get_description().is_some());
+}
+
+#[wasm_bindgen_test]
+fn disconnected_view_renders_in_wasm() {
+    let app = test_piggui();
+    let _view = app.view();
+}
+
+#[wasm_bindgen_test]
+fn connected_view_renders_in_wasm() {
+    let app = test_piggui_connected();
+    let _view = app.view();
+}


### PR DESCRIPTION
## Summary
- Fix blank screen in wasm build: add `fira-sans` feature to all iced configurations (root cause: no embedded font for wasm where system fonts aren't available)
- Add "Connect to remote Pi..." option to the disconnected menu (was only in discovery-gated devices_menu, inaccessible in wasm or non-discovery builds)
- Add clipboard paste workaround for iced wasm ([iced-rs/iced#2108](https://github.com/iced-rs/iced/issues/2108))
- Move sysinfo to non-wasm dependencies, fix Cargo.toml metadata
- Gate desktop-only settings (window_size, exit_on_close_request) behind non-wasm cfg
- Switch wasm builds to release mode with wasm-opt
- Add `wasm-bindgen-test` smoke tests for wasm target
- Add `web-run` target to root Makefile

Closes #936

## Test plan
- [x] All 68 native tests pass
- [x] All feature combinations build
- [x] Wasm builds successfully
- [x] Browser renders "Disconnected" UI with readable text
- [x] Connect dialog accessible from disconnected menu
- [x] Paste workaround works in connect dialog fields
- [x] Successfully connected to local pigglet via iroh from browser
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)