### PR TITLE
Support URL query parameters for auto-connect in browser

### DIFF
--- a/piggui/Cargo.toml
+++ b/piggui/Cargo.toml
@@ -64,7 +64,7 @@ piggpio = { path = "../piggpio", version = "0.7" }
 # wasm32 - Use 'tiny-skia' software renderer in iced
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
-web-sys = { version = "0.3", features = ["Window", "Location"] }
+web-sys = { version = "0.3", features = ["Window", "Location", "UrlSearchParams"] }
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
 iced = { version = "0.14.0", default-features = false, features = ["tokio", "tiny-skia", "fira-sans", "advanced", "canvas"] }
 

--- a/piggui/Cargo.toml
+++ b/piggui/Cargo.toml
@@ -64,6 +64,7 @@ piggpio = { path = "../piggpio", version = "0.7" }
 # wasm32 - Use 'tiny-skia' software renderer in iced
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
+web-sys = { version = "0.3", features = ["Window", "Location"] }
 getrandom = { version = "0.4.2", features = ["wasm_js"] }
 iced = { version = "0.14.0", default-features = false, features = ["tokio", "tiny-skia", "fira-sans", "advanced", "canvas"] }
 

--- a/piggui/src/piggui.rs
+++ b/piggui/src/piggui.rs
@@ -623,26 +623,24 @@ impl Piggui {
             .and_then(|w| w.location().search().ok())
             .unwrap_or_default();
 
-        let params: std::collections::HashMap<String, String> = search
-            .trim_start_matches('?')
-            .split('&')
-            .filter_map(|pair| {
-                let mut parts = pair.splitn(2, '=');
-                Some((parts.next()?.to_string(), parts.next()?.to_string()))
-            })
-            .collect();
+        let params = match web_sys::UrlSearchParams::new_with_str(&search) {
+            Ok(p) => p,
+            Err(_) => return NoConnection,
+        };
 
         #[cfg(feature = "iroh")]
         if let Some(endpoint_id_str) = params.get("endpoint_id") {
-            if let Ok(endpoint_id) = EndpointId::from_str(endpoint_id_str) {
-                let relay_url = params.get("relay").and_then(|r| RelayUrl::from_str(r).ok());
+            if let Ok(endpoint_id) = EndpointId::from_str(&endpoint_id_str) {
+                let relay_url = params
+                    .get("relay")
+                    .and_then(|r| RelayUrl::from_str(&r).ok());
                 return HardwareConnection::Iroh(endpoint_id, relay_url);
             }
         }
 
         #[cfg(feature = "tcp")]
         if let Some(ip_str) = params.get("ip") {
-            if let Ok(tcp_target) = parse_ip_string(ip_str) {
+            if let Ok(tcp_target) = parse_ip_string(&ip_str) {
                 return tcp_target;
             }
         }

--- a/piggui/src/piggui.rs
+++ b/piggui/src/piggui.rs
@@ -27,7 +27,7 @@ use crate::Message::*;
 use clap::{Arg, ArgMatches};
 use iced::widget::{container, Column};
 use iced::{window, Element, Length, Pixels, Settings, Subscription, Task, Theme};
-#[cfg(all(feature = "iroh", not(target_arch = "wasm32")))]
+#[cfg(feature = "iroh")]
 use iroh::{EndpointId, RelayUrl};
 use pigdef::config::HardwareConfig;
 #[cfg(feature = "usb")]
@@ -44,7 +44,7 @@ use pignet::HardwareConnection::NoConnection;
 use std::collections::HashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::process;
-#[cfg(all(any(feature = "iroh", feature = "tcp"), not(target_arch = "wasm32")))]
+#[cfg(any(feature = "iroh", feature = "tcp"))]
 use std::str::FromStr;
 #[cfg(not(target_arch = "wasm32"))]
 use sysinfo::{Process, System};
@@ -206,8 +206,10 @@ impl Piggui {
 
         #[cfg(target_arch = "wasm32")]
         #[allow(unused_variables)]
-        let (requested_connection, local_hardware_option) =
-            (NoConnection, Option::<HardwareConnection>::None);
+        let (requested_connection, local_hardware_option) = {
+            let connection = Self::parse_url_params();
+            (connection, Option::<HardwareConnection>::None)
+        };
 
         #[cfg(feature = "discovery")]
         let discovered_devices = discovery::local_discovery(local_hardware_option);
@@ -613,6 +615,39 @@ impl Piggui {
         }
 
         (connection, local_hardware_opt, tasks)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn parse_url_params() -> HardwareConnection {
+        let search = web_sys::window()
+            .and_then(|w| w.location().search().ok())
+            .unwrap_or_default();
+
+        let params: std::collections::HashMap<String, String> = search
+            .trim_start_matches('?')
+            .split('&')
+            .filter_map(|pair| {
+                let mut parts = pair.splitn(2, '=');
+                Some((parts.next()?.to_string(), parts.next()?.to_string()))
+            })
+            .collect();
+
+        #[cfg(feature = "iroh")]
+        if let Some(endpoint_id_str) = params.get("endpoint_id") {
+            if let Ok(endpoint_id) = EndpointId::from_str(endpoint_id_str) {
+                let relay_url = params.get("relay").and_then(|r| RelayUrl::from_str(r).ok());
+                return HardwareConnection::Iroh(endpoint_id, relay_url);
+            }
+        }
+
+        #[cfg(feature = "tcp")]
+        if let Some(ip_str) = params.get("ip") {
+            if let Ok(tcp_target) = parse_ip_string(ip_str) {
+                return tcp_target;
+            }
+        }
+
+        NoConnection
     }
 }
 


### PR DESCRIPTION
## Summary
- Parse URL query parameters (`endpoint_id`, `relay`, `ip`) on wasm startup to auto-connect to a pigglet
- Enables sharing connection URLs like: `http://host:port/?endpoint_id=<id>`
- Add `web-sys` dependency with `Window` and `Location` features for URL parsing
- Broaden iroh and FromStr imports to be available on wasm (were previously gated to non-wasm only)

Closes #1254

## Test plan
- [x] All 63 native tests pass
- [x] Wasm builds successfully
- [x] Tested auto-connect: `http://127.0.0.1:8080/?endpoint_id=<id>` connects to local pigglet
- [x] Without params, shows disconnected view as before
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)