### PR TITLE
Re-enable jonesy fail-on-panic

### DIFF
--- a/.github/workflows/jonesy.yml
+++ b/.github/workflows/jonesy.yml
@@ -21,9 +21,7 @@ jobs:
         id: jonesy
         uses: andrewdavidmackenzie/jonesy@v1
         with:
-          # TODO: set to true once https://github.com/andrewdavidmackenzie/jonesy/issues/253 is fixed
-          # See https://github.com/andrewdavidmackenzie/pigg/issues/1263
-          fail-on-panic: false
+          fail-on-panic: true
           extra-args: '--config jonesy.toml'
 
       - name: Check panic count


### PR DESCRIPTION
## Summary
- Re-enable `fail-on-panic: true` in jonesy CI workflow now that jonesy 0.9.1 fixes inline allow comments in rlib crate analysis
- Removes TODO comments referencing the upstream fix

Closes #1263

## Test plan
- [x] Verified locally: all 5 workspace crates pass with 0 panic points on jonesy 0.9.1
- [ ] CI jonesy workflow passes with `fail-on-panic: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)