### PR TITLE
fix: Pin lcov to v2.4 to fix CI Setup LCOV failures

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: hrishikesh-kadam/setup-lcov@v1
         with:
-          ref: HEAD
+          ref: v2.4
 
       - name: build and test - non-Linux
         if: runner.os != 'Linux'


### PR DESCRIPTION
## Summary
- Pin `hrishikesh-kadam/setup-lcov` from `ref: HEAD` to `ref: v2.4`
- lcov HEAD now requires `sphinx-build` for documentation, which isn't available on GitHub Actions runners, causing ubuntu and macOS jobs to fail at the "Setup LCOV" step

## Test plan
- [ ] CI build-and-test-matrix passes on ubuntu and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)